### PR TITLE
Add workflow_dispatch type to Update Links workflow

### DIFF
--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -4,6 +4,8 @@ name: Update Links
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs: {}
 
 jobs:
   update-links:


### PR DESCRIPTION
This PR adds the workflow_dispatch type to the Update Links workflow.  This will allow running manually if needed.