### PR TITLE
Add version.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
           artifacts: 'bitwarden.sh,
                       run.sh,
                       bitwarden.ps1,
-                      run.ps1'
+                      run.ps1,
+                      version.json'
           commit: ${{ github.sha }}
           tag: "v${{ github.event.inputs.release_version }}"
           name: "Version ${{ github.event.inputs.release_version }}"

--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -36,6 +36,14 @@ jobs:
             echo "::set-output name=value::$GITHUB_REF_NAME"
           fi
 
+      - name: Update Bitwarden Version Link
+        uses: bitwarden/gh-actions/update-rebrandly-link@340a677ffb0c53e50ca67cd2c12044cd7f7fc725
+        with:
+          apikey: ${{ steps.retrieve-secrets.outputs.rebrandly-apikey }}
+          domain: "go.btwrdn.co"
+          slashtag: "bw-sh-versions"
+          destination: "https://github.com/bitwarden/self-host/releases/download/${{ steps.tag-name.outputs.value }}/version.json"
+
       - name: Update Bitwarden Script PowerShell Link
         uses: bitwarden/gh-actions/update-rebrandly-link@340a677ffb0c53e50ca67cd2c12044cd7f7fc725
         with:

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           LATEST_CORE_VERSION: ${{ steps.get-core.outputs.version }}
         run: |
-          CORE_VERSION=$(sed -r -n "s/COREVERSION=\"([0-9]+\.[0-9]+\.[0-9]+)\"/\1/p" bitwarden.sh)
+          CORE_VERSION=$(grep '^ *"coreVersion":' version.json | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
           echo "Core Version: $CORE_VERSION"
           echo "Latest Core Version: $LATEST_CORE_VERSION"
           if [ "$CORE_VERSION" != "$LATEST_CORE_VERSION" ]; then
@@ -54,7 +54,7 @@ jobs:
         env:
           LATEST_WEB_VERSION: ${{ steps.get-web.outputs.version }}
         run: |
-          WEB_VERSION=$(sed -r -n "s/WEBVERSION=\"([0-9]+\.[0-9]+\.[0-9]+)\"/\1/p" bitwarden.sh)
+          WEB_VERSION=$(grep '^ *"webVersion":' version.json | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
           echo "Web Version: $WEB_VERSION"
           echo "Latest Web Version: $LATEST_WEB_VERSION"
           if [ "$WEB_VERSION" != "$LATEST_WEB_VERSION" ]; then
@@ -75,7 +75,7 @@ jobs:
         env:
           LATEST_KEY_CONNECTOR_VERSION: ${{ steps.get-key-connector.outputs.version }}
         run: |
-          KEY_CONNECTOR_VERSION=$(sed -r -n "s/KEYCONNECTORVERSION=\"([0-9]+\.[0-9]+\.[0-9]+)\"/\1/p" bitwarden.sh)
+          KEY_CONNECTOR_VERSION=$(grep '^ *"keyConnectorVersion":' version.json | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
           echo "Key Connector Version: $KEY_CONNECTOR_VERSION"
           echo "Latest Key Connector Version: $LATEST_KEY_CONNECTOR_VERSION"
           if [ "$KEY_CONNECTOR_VERSION" != "$LATEST_KEY_CONNECTOR_VERSION" ]; then
@@ -111,23 +111,17 @@ jobs:
       - name: Update Core Version
         env:
           VERSION: ${{ needs.setup.outputs.core_version }}
-        run: |
-          sed -i -e "/^\s*COREVERSION\s*=\s*/s/[0-9]\+.[0-9]\+.[0-9]\+/$VERSION/" bitwarden.sh
-          sed -i -e "/^\s*\$coreVersion\s*=\s*/s/[0-9]\+.[0-9]\+.[0-9]\+/$VERSION/" bitwarden.ps1
+        run: sed -i -e '/"coreVersion":/ s/"coreVersion":[^,]*/"coreVersion":"'$VERSION'"/' version.json
 
       - name: Update Web Version
         env:
           VERSION: ${{ needs.setup.outputs.web_version }}
-        run: |
-          sed -i -e "/^\s*WEBVERSION\s*=\s*/s/[0-9]\+.[0-9]\+.[0-9]\+/$VERSION/" bitwarden.sh
-          sed -i -e "/^\s*\$webVersion\s*=\s*/s/[0-9]\+.[0-9]\+.[0-9]\+/$VERSION/" bitwarden.ps1
+        run: sed -i -e '/"webVersion":/ s/"webVersion":[^,]*/"webVersion":"'$VERSION'"/' version.json
 
       - name: Update Key Connector Version
         env:
           VERSION: ${{ needs.setup.outputs.key_connector_version }}
-        run: |
-          sed -i -e "/^\s*KEYCONNECTORVERSION\s*=\s*/s/[0-9]\+.[0-9]\+.[0-9]\+/$VERSION/" bitwarden.sh
-          sed -i -e "/^\s*\$keyConnectorVersion\s*=\s*/s/[0-9]\+.[0-9]\+.[0-9]\+/$VERSION/" bitwarden.ps1
+        run: sed -i -e '/"keyConnectorVersion":/ s/"keyConnectorVersion":[^,]*/"keyConnectorVersion":"'$VERSION'"/' version.json
 
       - name: Commit updated files
         run: |
@@ -158,4 +152,4 @@ jobs:
               - [X] Other
 
               ## Objective
-              Automated version updates to core, web, and key-connector versions in bitwarden.sh and bitwarden.ps1."
+              Automated version updates to core, web, and key-connector versions in `version.json`."

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           LATEST_CORE_VERSION: ${{ steps.get-core.outputs.version }}
         run: |
-          CORE_VERSION=$(grep '^ *"coreVersion":' version.json | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+          CORE_VERSION=$(grep '^ *"coreVersion":' version.json | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
           echo "Core Version: $CORE_VERSION"
           echo "Latest Core Version: $LATEST_CORE_VERSION"
           if [ "$CORE_VERSION" != "$LATEST_CORE_VERSION" ]; then
@@ -54,7 +54,7 @@ jobs:
         env:
           LATEST_WEB_VERSION: ${{ steps.get-web.outputs.version }}
         run: |
-          WEB_VERSION=$(grep '^ *"webVersion":' version.json | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+          WEB_VERSION=$(grep '^ *"webVersion":' version.json | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
           echo "Web Version: $WEB_VERSION"
           echo "Latest Web Version: $LATEST_WEB_VERSION"
           if [ "$WEB_VERSION" != "$LATEST_WEB_VERSION" ]; then
@@ -75,7 +75,7 @@ jobs:
         env:
           LATEST_KEY_CONNECTOR_VERSION: ${{ steps.get-key-connector.outputs.version }}
         run: |
-          KEY_CONNECTOR_VERSION=$(grep '^ *"keyConnectorVersion":' version.json | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+          KEY_CONNECTOR_VERSION=$(grep '^ *"keyConnectorVersion":' version.json | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
           echo "Key Connector Version: $KEY_CONNECTOR_VERSION"
           echo "Latest Key Connector Version: $LATEST_KEY_CONNECTOR_VERSION"
           if [ "$KEY_CONNECTOR_VERSION" != "$LATEST_KEY_CONNECTOR_VERSION" ]; then
@@ -111,7 +111,7 @@ jobs:
       - name: Update Core Version
         env:
           VERSION: ${{ needs.setup.outputs.core_version }}
-        run: sed -i -e '/"coreVersion":/ s/"coreVersion":[^,]*/"coreVersion":"'$VERSION'"/' version.json
+        run: sed -i -e '/"coreVersion":/ s/"coreVersion":[^,]*/"coreVersion":"' $VERSION'"/' version.json
 
       - name: Update Web Version
         env:

--- a/bitwarden.ps1
+++ b/bitwarden.ps1
@@ -26,11 +26,12 @@ if ($output -eq "") {
 $scriptsDir = "${output}\scripts"
 $bitwardenScriptUrl = "https://go.btwrdn.co/bw-ps"
 $runScriptUrl = "https://go.btwrdn.co/bw-ps-run"
+$versionEndpoint = "https://go.btwrdn.co/bw-sh-versions"
 
 # Please do not create pull requests modifying the version numbers.
-$coreVersion = "1.47.1"
-$webVersion = "2.27.0"
-$keyConnectorVersion = "1.0.1"
+$coreVersion = (Invoke-RestMethod -Uri $versionEndpoint).versions.coreVersion 
+$webVersion = (Invoke-RestMethod -Uri $versionEndpoint).versions.webVersion 
+$keyConnectorVersion = (Invoke-RestMethod -Uri $versionEndpoint).versions.keyConnectorVersion 
 
 # Functions
 

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -43,7 +43,7 @@ VERSION_ENDPOINT="https://go.btwrdn.co/bw-sh-versions"
 
 # Please do not create pull requests modifying the version numbers.
 function getVersion() {
-    echo $(curl -sL $VERSION_ENDPOINT | grep  '^ *"'${1}'":' | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+    echo $(curl -sL $VERSION_ENDPOINT | grep  '^ *"'${1}'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
 }
 
 COREVERSION=$(getVersion coreVersion)

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -39,11 +39,16 @@ fi
 SCRIPTS_DIR="$OUTPUT/scripts"
 BITWARDEN_SCRIPT_URL="https://go.btwrdn.co/bw-sh"
 RUN_SCRIPT_URL="https://go.btwrdn.co/bw-sh-run"
+VERSION_ENDPOINT="https://go.btwrdn.co/bw-sh-versions"
 
 # Please do not create pull requests modifying the version numbers.
-COREVERSION="1.47.1"
-WEBVERSION="2.27.0"
-KEYCONNECTORVERSION="1.0.1"
+function getVersion() {
+    echo $(curl -sL $VERSION_ENDPOINT | grep  '^ *"'${1}'":' | awk '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+}
+
+COREVERSION=$(getVersion coreVersion)
+WEBVERSION=$(getVersion webVersion)
+KEYCONNECTORVERSION=$(getVersion keyConnectorVersion)
 
 echo "bitwarden.sh version $COREVERSION"
 docker --version

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-      "coreVersion": "1.47.0",
-      "webVersion": "2.26.0",
-      "keyConnectorVersion": "1.0.1"
+      "coreVersion":"1.47.1",
+      "webVersion":"2.27.0",
+      "keyConnectorVersion":"1.0.1"
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-      "coreVersion": "1.47.1",
-      "webVersion": "2.27.0",
+      "coreVersion": "1.47.0",
+      "webVersion": "2.26.0",
       "keyConnectorVersion": "1.0.1"
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,0 +1,7 @@
+{
+  "versions": {
+      "coreVersion": "1.47.1",
+      "webVersion": "2.27.0",
+      "keyConnectorVersion": "1.0.1"
+  }
+}


### PR DESCRIPTION
- Adds version.json with core, web, and KC versions
- Updated Bitwarden scripts to query VERSION_ENDPOINT
- VERSION_ENDPOINT is set to Rebrandly link, redirecting to version.json
- Workflows updated to handle new link, version.json, and version bumps.

---
For testing:

1. Update Rebrandly link to point to this raw file https://raw.githubusercontent.com/bitwarden/self-host/e31909dddb68a6ce16fe9ea8906f6d018ec05fa8/version.json

2. On a new line before line number 61, place a `return`. https://github.com/bitwarden/self-host/pull/17/files#diff-e09e1b8249873e4d6c69fad97e494a37f9380c7894e347072d8735f920a4c555L61

3. Run the `bitwarden.sh install` command.