### PR TITLE
[DEVOPS-832] Update timing on SelfHost "latest" tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,20 +60,20 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.branch-name }}
 
-      - name: Create release
-        uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09
-        with:
-          artifacts: 'bitwarden.sh,
-                      run.sh,
-                      bitwarden.ps1,
-                      run.ps1,
-                      version.json'
-          commit: ${{ github.sha }}
-          tag: "v${{ github.event.inputs.release_version }}"
-          name: "Version ${{ github.event.inputs.release_version }}"
-          body: "<insert release notes here>"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
+      # - name: Create release
+      #   uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09
+      #   with:
+      #     artifacts: 'bitwarden.sh,
+      #                 run.sh,
+      #                 bitwarden.ps1,
+      #                 run.ps1,
+      #                 version.json'
+      #     commit: ${{ github.sha }}
+      #     tag: "v${{ github.event.inputs.release_version }}"
+      #     name: "Version ${{ github.event.inputs.release_version }}"
+      #     body: "<insert release notes here>"
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     draft: true
 
   release-version:
     name: Upload version.json
@@ -99,16 +99,16 @@ jobs:
           keyvault: "bitwarden-prod-kv"
           secrets: "aws-selfhost-version-access-id, aws-selfhost-version-access-key"
 
-      - name: Upload version.json to S3 bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
-          AWS_DEFAULT_REGION: 'us-west-2'
-          AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
-        run: |
-          aws s3 cp version.json $AWS_S3_BUCKET_NAME \
-          --acl "public-read" \
-          --quiet
+      # - name: Upload version.json to S3 bucket
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
+      #     AWS_DEFAULT_REGION: 'us-west-2'
+      #     AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
+      #   run: |
+      #     aws s3 cp version.json $AWS_S3_BUCKET_NAME \
+      #     --acl "public-read" \
+      #     --quiet
 
   tag-docker-latest:
     name: Tag Docker image latest
@@ -139,14 +139,11 @@ jobs:
           - service_name: Web
     steps:
       - name: Print environment
-        env:
-          RELEASE_OPTION: ${{ github.event.inputs.release_type }}
         run: |
           whoami
           docker --version
           echo "GitHub ref: $GITHUB_REF"
           echo "GitHub event: $GITHUB_EVENT"
-          echo "Github Release Option: $RELEASE_OPTION"
 
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
     outputs:
       branch-name: ${{ steps.branch.outputs.branch-name }}
     steps:
-      # - name: Branch check
-      #   run: |
-      #     if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix" ]]; then
-      #       echo "==================================="
-      #       echo "[!] Can only release from the 'rc' or 'hotfix' branches"
-      #       echo "==================================="
-      #       exit 1
-      #     fi
+      - name: Branch check
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from the 'rc' or 'hotfix' branches"
+            echo "==================================="
+            exit 1
+          fi
 
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -60,20 +60,20 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.branch-name }}
 
-      # - name: Create release
-      #   uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09
-      #   with:
-      #     artifacts: 'bitwarden.sh,
-      #                 run.sh,
-      #                 bitwarden.ps1,
-      #                 run.ps1,
-      #                 version.json'
-      #     commit: ${{ github.sha }}
-      #     tag: "v${{ github.event.inputs.release_version }}"
-      #     name: "Version ${{ github.event.inputs.release_version }}"
-      #     body: "<insert release notes here>"
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     draft: true
+      - name: Create release
+        uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09
+        with:
+          artifacts: 'bitwarden.sh,
+                      run.sh,
+                      bitwarden.ps1,
+                      run.ps1,
+                      version.json'
+          commit: ${{ github.sha }}
+          tag: "v${{ github.event.inputs.release_version }}"
+          name: "Version ${{ github.event.inputs.release_version }}"
+          body: "<insert release notes here>"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
 
   release-version:
     name: Upload version.json
@@ -99,16 +99,16 @@ jobs:
           keyvault: "bitwarden-prod-kv"
           secrets: "aws-selfhost-version-access-id, aws-selfhost-version-access-key"
 
-      # - name: Upload version.json to S3 bucket
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
-      #     AWS_DEFAULT_REGION: 'us-west-2'
-      #     AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
-      #   run: |
-      #     aws s3 cp version.json $AWS_S3_BUCKET_NAME \
-      #     --acl "public-read" \
-      #     --quiet
+      - name: Upload version.json to S3 bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
+          AWS_DEFAULT_REGION: 'us-west-2'
+          AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
+        run: |
+          aws s3 cp version.json $AWS_S3_BUCKET_NAME \
+          --acl "public-read" \
+          --quiet
 
   tag-docker-latest:
     name: Tag Docker image latest
@@ -178,13 +178,13 @@ jobs:
         run: |
           docker tag bitwarden/$SERVICE_NAME:latest
 
-      # - name: Push latest image
-      #   env:
-      #     DOCKER_CONTENT_TRUST: 1
-      #     DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-      #     SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
-      #   run: |
-      #     docker push bitwarden/$SERVICE_NAME:latest
+      - name: Push latest image
+        env:
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+        run: |
+          docker push bitwarden/$SERVICE_NAME:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -207,12 +207,12 @@ jobs:
         run: |
           docker tag $REGISTRY/$SERVICE_NAME:latest
 
-      # - name: Push version and latest image
-      #   env:
-      #     SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
-      #     REGISTRY: bitwardenqa.azurecr.io
-      #   run: |
-      #     docker push $REGISTRY/$SERVICE_NAME:latest
+      - name: Push version and latest image
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+          REGISTRY: bitwardenqa.azurecr.io
+        run: |
+          docker push $REGISTRY/$SERVICE_NAME:latest
 
       - name: Log out of Docker
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
         run: |
-          docker pull $REGISTRY/$SERVICE_NAME:$_BRANCH_NAME
+          docker pull $REGISTRY/$SERVICE_NAME:$_RELEASE_VERSION
 
       - name: Tag latest
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
     outputs:
       branch-name: ${{ steps.branch.outputs.branch-name }}
     steps:
-      - name: Branch check
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix" ]]; then
-            echo "==================================="
-            echo "[!] Can only release from the 'rc' or 'hotfix' branches"
-            echo "==================================="
-            exit 1
-          fi
+      # - name: Branch check
+      #   run: |
+      #     if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix" ]]; then
+      #       echo "==================================="
+      #       echo "[!] Can only release from the 'rc' or 'hotfix' branches"
+      #       echo "==================================="
+      #       exit 1
+      #     fi
 
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
         run: |
-          docker tag bitwarden/$SERVICE_NAME:latest
+          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION bitwarden/$SERVICE_NAME:latest
 
       - name: Push latest image
         env:
@@ -205,7 +205,70 @@ jobs:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
         run: |
-          docker tag $REGISTRY/$SERVICE_NAME:latest
+          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
+
+      - name: Push version and latest image
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+          REGISTRY: bitwardenqa.azurecr.io
+        run: |
+          docker push $REGISTRY/$SERVICE_NAME:latest
+
+      - name: Log out of Docker
+        run: docker logout
+
+  tag-docker-web-sh-latest:
+    name: Tag Docker image latest
+    runs-on: ubuntu-20.04
+    needs:
+      - setup
+      - release
+    env:
+      _RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
+      SERVICE_NAME: web-sh
+    steps:
+      - name: Print environment
+        run: |
+          whoami
+          docker --version
+          echo "GitHub ref: $GITHUB_REF"
+          echo "GitHub event: $GITHUB_EVENT"
+
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: ${{ needs.setup.outputs.branch-name }}
+
+      - name: Setup service name
+        id: setup
+        run: |
+          SERVICE_NAME=$(echo "${{ matrix.service_name }}" | awk '{print tolower($0)}')
+          echo "Matrix name: ${{ matrix.service_name }}"
+          echo "SERVICE_NAME: $SERVICE_NAME"
+
+      ########## ACR ##########
+      - name: Login to Azure - QA Subscription
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+
+      - name: Login to Azure ACR
+        run: az acr login -n bitwardenqa
+
+      - name: Pull versioned image
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+          REGISTRY: bitwardenqa.azurecr.io
+        run: |
+          docker pull $REGISTRY/$SERVICE_NAME:$_BRANCH_NAME
+
+      - name: Tag latest
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+          REGISTRY: bitwardenqa.azurecr.io
+        run: |
+          docker tag $REGISTRY/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
 
       - name: Push version and latest image
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,3 +109,113 @@ jobs:
           aws s3 cp version.json $AWS_S3_BUCKET_NAME \
           --acl "public-read" \
           --quiet
+
+  tag-docker-latest:
+    name: Tag Docker image latest
+    runs-on: ubuntu-20.04
+    needs:
+      - setup
+      - release
+    env:
+      _RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service_name: Admin
+          - service_name: Api
+          - service_name: Attachments
+          - service_name: Events
+          - service_name: Icons
+          - service_name: Identity
+          - service_name: K8S-Proxy
+          - service_name: MsSql
+          - service_name: Nginx
+          - service_name: Notifications
+          - service_name: Server
+          - service_name: Setup
+          - service_name: Sso
+          - service_name: Web
+    steps:
+      - name: Print environment
+        env:
+          RELEASE_OPTION: ${{ github.event.inputs.release_type }}
+        run: |
+          whoami
+          docker --version
+          echo "GitHub ref: $GITHUB_REF"
+          echo "GitHub event: $GITHUB_EVENT"
+          echo "Github Release Option: $RELEASE_OPTION"
+
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: ${{ needs.setup.outputs.branch-name }}
+
+      - name: Setup service name
+        id: setup
+        run: |
+          SERVICE_NAME=$(echo "${{ matrix.service_name }}" | awk '{print tolower($0)}')
+          echo "Matrix name: ${{ matrix.service_name }}"
+          echo "SERVICE_NAME: $SERVICE_NAME"
+          echo "::set-output name=service_name::$SERVICE_NAME"
+
+      ########## DockerHub ##########
+      - name: Setup DCT
+        id: setup-dct
+        uses: bitwarden/gh-actions/setup-docker-trust@a8c384a05a974c05c48374c818b004be221d43ff
+        with:
+          azure-creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+          azure-keyvault-name: "bitwarden-prod-kv"
+
+      - name: Pull versioned image
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+        run: |
+          docker pull bitwarden/$SERVICE_NAME:$_RELEASE_VERSION
+
+      - name: Tag latest
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+        run: |
+          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION bitwarden/$SERVICE_NAME:latest
+
+      - name: Push latest image
+        env:
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+        run: |
+          docker push bitwarden/$SERVICE_NAME:latest
+
+      - name: Log out of Docker and disable Docker Notary
+        run: |
+          docker logout
+          echo "DOCKER_CONTENT_TRUST=0" >> $GITHUB_ENV
+
+      ########## ACR ##########
+      - name: Login to Azure - QA Subscription
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+
+      - name: Login to Azure ACR
+        run: az acr login -n bitwardenqa
+
+      - name: Tag version and latest
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+          REGISTRY: bitwardenqa.azurecr.io
+        run: |
+          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
+
+      - name: Push version and latest image
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+          REGISTRY: bitwardenqa.azurecr.io
+        run: |
+          docker push $REGISTRY/$SERVICE_NAME:latest
+
+      - name: Log out of Docker
+        run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,13 +181,13 @@ jobs:
         run: |
           docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION bitwarden/$SERVICE_NAME:latest
 
-      - name: Push latest image
-        env:
-          DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
-        run: |
-          docker push bitwarden/$SERVICE_NAME:latest
+      # - name: Push latest image
+      #   env:
+      #     DOCKER_CONTENT_TRUST: 1
+      #     DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+      #     SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+      #   run: |
+      #     docker push bitwarden/$SERVICE_NAME:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -210,12 +210,12 @@ jobs:
         run: |
           docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
 
-      - name: Push version and latest image
-        env:
-          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
-          REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker push $REGISTRY/$SERVICE_NAME:latest
+      # - name: Push version and latest image
+      #   env:
+      #     SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+      #     REGISTRY: bitwardenqa.azurecr.io
+      #   run: |
+      #     docker push $REGISTRY/$SERVICE_NAME:latest
 
       - name: Log out of Docker
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
         run: |
-          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION bitwarden/$SERVICE_NAME:latest
+          docker tag bitwarden/$SERVICE_NAME:latest
 
       # - name: Push latest image
       #   env:
@@ -200,12 +200,12 @@ jobs:
       - name: Login to Azure ACR
         run: az acr login -n bitwardenqa
 
-      - name: Tag version and latest
+      - name: Tag latest
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
         run: |
-          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
+          docker tag $REGISTRY/$SERVICE_NAME:latest
 
       # - name: Push version and latest image
       #   env:


### PR DESCRIPTION
Move the `latest` tag to be created on update to the self-host script instead of the server/web releases.

Related PRs:
- https://github.com/bitwarden/clients/pull/3044
- https://github.com/bitwarden/server/pull/2098