### PR TITLE
Monorepo support for `get-release-version` workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   setup:
     name: Setup
-    if: github.ref_name == 'master' || github.ref_name == 'rc' || github.ref_name == 'hotfix'
+    if: github.ref_name == 'DEVOPS-873-update-self-host-update-version-to-support-monorepo' || github.ref_name == 'rc' || github.ref_name == 'hotfix'
     runs-on: ubuntu-20.04
     outputs:
       core_version: ${{ steps.get-core.outputs.version }}

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -24,9 +24,10 @@ jobs:
 
       - name: Get Latest Core Version
         id: get-core
-        uses: bitwarden/gh-actions/get-release-version@aa9092a81c74b0c5dd6c7feb7ff345bb4aaf3d85
+        uses: bitwarden/gh-actions/get-release-version@606c654d077a4eb540e063eda1676181cae730cf
         with:
           repository: bitwarden/server
+          trim: true
 
       - name: Check if Core Version needs updating
         id: core-update
@@ -45,11 +46,12 @@ jobs:
 
       - name: Get Latest Web Version
         id: get-web
-        uses: bitwarden/gh-actions/get-release-version@aa9092a81c74b0c5dd6c7feb7ff345bb4aaf3d85
+        uses: bitwarden/gh-actions/get-release-version@606c654d077a4eb540e063eda1676181cae730cf
         with:
           repository: bitwarden/clients
           monorepo: true
           monorepo-project: web
+          trim: true
 
       - name: Check if Web Version needs updating
         id: web-update
@@ -68,9 +70,10 @@ jobs:
 
       - name: Get Latest Key Connector Version
         id: get-key-connector
-        uses: bitwarden/gh-actions/get-release-version@aa9092a81c74b0c5dd6c7feb7ff345bb4aaf3d85
+        uses: bitwarden/gh-actions/get-release-version@606c654d077a4eb540e063eda1676181cae730cf
         with:
           repository: bitwarden/key-connector
+          trim: true
 
       - name: Check if Key Connector Version needs updating
         id: key-connector-update

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get Latest Core Version
         id: get-core
-        uses: bitwarden/gh-actions/get-release-version@664c8899c95490c65dac0df11519d24ed8419c85
+        uses: bitwarden/gh-actions/get-release-version@aa9092a81c74b0c5dd6c7feb7ff345bb4aaf3d85
         with:
           repository: bitwarden/server
 
@@ -45,9 +45,11 @@ jobs:
 
       - name: Get Latest Web Version
         id: get-web
-        uses: bitwarden/gh-actions/get-release-version@664c8899c95490c65dac0df11519d24ed8419c85
+        uses: bitwarden/gh-actions/get-release-version@aa9092a81c74b0c5dd6c7feb7ff345bb4aaf3d85
         with:
           repository: bitwarden/web
+          monorepo: true
+          monorepo-project: web
 
       - name: Check if Web Version needs updating
         id: web-update
@@ -66,7 +68,7 @@ jobs:
 
       - name: Get Latest Key Connector Version
         id: get-key-connector
-        uses: bitwarden/gh-actions/get-release-version@664c8899c95490c65dac0df11519d24ed8419c85
+        uses: bitwarden/gh-actions/get-release-version@aa9092a81c74b0c5dd6c7feb7ff345bb4aaf3d85
         with:
           repository: bitwarden/key-connector
 

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -47,7 +47,7 @@ jobs:
         id: get-web
         uses: bitwarden/gh-actions/get-release-version@aa9092a81c74b0c5dd6c7feb7ff345bb4aaf3d85
         with:
-          repository: bitwarden/web
+          repository: bitwarden/clients
           monorepo: true
           monorepo-project: web
 

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get Latest Core Version
         id: get-core
-        uses: bitwarden/gh-actions/get-release-version@606c654d077a4eb540e063eda1676181cae730cf
+        uses: bitwarden/gh-actions/get-release-version@47be0695ac64ecdc8a3f7ad03d1a6ef9160de256
         with:
           repository: bitwarden/server
           trim: true
@@ -46,7 +46,7 @@ jobs:
 
       - name: Get Latest Web Version
         id: get-web
-        uses: bitwarden/gh-actions/get-release-version@606c654d077a4eb540e063eda1676181cae730cf
+        uses: bitwarden/gh-actions/get-release-version@47be0695ac64ecdc8a3f7ad03d1a6ef9160de256
         with:
           repository: bitwarden/clients
           monorepo: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: Get Latest Key Connector Version
         id: get-key-connector
-        uses: bitwarden/gh-actions/get-release-version@606c654d077a4eb540e063eda1676181cae730cf
+        uses: bitwarden/gh-actions/get-release-version@47be0695ac64ecdc8a3f7ad03d1a6ef9160de256
         with:
           repository: bitwarden/key-connector
           trim: true


### PR DESCRIPTION
Updates the `bitwarden/gh-actions/get-release-version` action to use the new monorepo support.

Requires PR [[58](https://github.com/bitwarden/gh-actions/pull/58)] and the commit hash before merge.