### PR TITLE
EC-334-update-run.sh-grep-command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -195,7 +195,7 @@ function updateDatabase() {
 }
 
 function updatebw() {
-    KEY_CONNECTOR_ENABLED=$(grep -A3 'enable_key_connector:' $OUTPUT_DIR/config.yml | tail -n1 | awk '{ print $2}')
+    KEY_CONNECTOR_ENABLED=$(grep 'enable_key_connector:' $OUTPUT_DIR/config.yml | awk '{ print $2}')
     CORE_ID=$($dccmd ps -q admin)
     WEB_ID=$($dccmd ps -q web)
     if [ "$KEY_CONNECTOR_ENABLED" = true ];


### PR DESCRIPTION
modified the grep command after testing on my DevOps provided self host to verify that it can successfully check if the key connector value in bwdata/config.yml is set to true or not