### PR TITLE
Add check for run file download failure

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -79,7 +79,7 @@ function downloadRunFile() {
         rm -f $SCRIPTS_DIR/install.sh
     else
         echo "Unable to download run script from $RUN_SCRIPT_URL. Received status code: $run_file_status_code"
-        echo "http responnse:"
+        echo "http response:"
         cat $SCRIPTS_DIR/run.sh
         rm -f $SCRIPTS_DIR/run.sh
         exit 1

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -72,9 +72,18 @@ function downloadRunFile() {
     then
         mkdir $SCRIPTS_DIR
     fi
-    curl -L -s -o $SCRIPTS_DIR/run.sh $RUN_SCRIPT_URL
-    chmod u+x $SCRIPTS_DIR/run.sh
-    rm -f $SCRIPTS_DIR/install.sh
+    run_file_status_code=$(curl -s -L -w "%{http_code}" -o $SCRIPTS_DIR/run.sh $RUN_SCRIPT_URL)
+    if echo "$run_file_status_code" | grep -q "^20[0-9]"
+    then
+        chmod u+x $SCRIPTS_DIR/run.sh
+        rm -f $SCRIPTS_DIR/install.sh
+    else
+        echo "Unable to download run script from $RUN_SCRIPT_URL. Received status code: $run_file_status_code"
+        echo "http responnse:"
+        cat $SCRIPTS_DIR/run.sh
+        rm -f $SCRIPTS_DIR/run.sh
+        exit 1
+    fi
 }
 
 function checkOutputDirExists() {


### PR DESCRIPTION
I encountered tthis issue when `bitwarden.sh` got a `429 Too many requests` response from azure but still stored the erroneous output in `run.sh` and tried to execute it.

```
run.sh: line 1: `System.Net.Http.HttpRequestException: Response status code does not indicate success: 429 (Too Many Requests).'

run.sh: line 1: syntax error near unexpected token `('
```

Complete response it got from Azure:

```
$ cat bwdata/scripts/run.sh
System.Net.Http.HttpRequestException: Response status code does not indicate success: 429 (Too Many Requests).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at System.Net.Http.HttpClient.GetStringAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
   at Proxies.Downloads.GetDownloadResponseAsync(String repository, String filename, ILogger log) in /home/runner/work/misc/misc/AzureFunctions/prod/AppFunctions/Downloads.cs:line 20
```

So I just added this check primarily to make sure such a respone is not executed.