### PR TITLE
Update deprecated Azure Key Vault in workflows

### DIFF
--- a/.github/workflows/release-digital-ocean.yml
+++ b/.github/workflows/release-digital-ocean.yml
@@ -27,10 +27,17 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
-        with:
-          keyvault: "bitwarden-prod-kv"
-          secrets: "digital-ocean-api-key"
+        env:
+          KEYVAULT: bitwarden-prod-kv
+          SECRETS: |
+            digital-ocean-api-key
+        run: |
+          for i in ${SECRETS//,/ }
+          do
+            VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
+            echo "::add-mask::$VALUE"
+            echo "::set-output name=$i::$VALUE"
+          done
 
       - name: Set version from version.json
         id: set-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,18 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@b5c723b9ac7870c022b8c35befe620b7009b336f
-        with:
-          keyvault: "bitwarden-prod-kv"
-          secrets: "aws-selfhost-version-access-id, aws-selfhost-version-access-key"
+        env:
+          KEYVAULT: bitwarden-prod-kv
+          SECRETS: |
+            aws-selfhost-version-access-id,
+            aws-selfhost-version-access-key
+        run: |
+          for i in ${SECRETS//,/ }
+          do
+            VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
+            echo "::add-mask::$VALUE"
+            echo "::set-output name=$i::$VALUE"
+          done
 
       - name: Upload version.json to S3 bucket
         env:

--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -22,10 +22,17 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-prod-kv"
-          secrets: "rebrandly-apikey"
+        env:
+          KEYVAULT: bitwarden-prod-kv
+          SECRETS: |
+            rebrandly-apikey
+        run: |
+          for i in ${SECRETS//,/ }
+          do
+            VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
+            echo "::add-mask::$VALUE"
+            echo "::set-output name=$i::$VALUE"
+          done
 
       - name: Set tag name
         id: tag-name


### PR DESCRIPTION
The GitHub action Azure Key Vault is being deprecated and will no longer be maintained. The outcome of the related spike offers a solution to implement as a drop-in replacement using bash and the Az CLI. All references for the `Azure/get-keyvault-secrets` action will need to be replaced with this bash step in all our workflows.