### PR TITLE
Allow Let's Encrypt random sleep on renewal to be disabled

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -164,13 +164,21 @@ function dockerPrune() {
         --filter="label!=com.bitwarden.project=setup"
 }
 
+function preventLetsEncryptRandomSleepOnRenew() {
+    if [ -f "${OUTPUT_DIR}/config.yml" ] &&
+        grep -q -E "^lets_encrypt_no_random_sleep_on_renew: true" "${OUTPUT_DIR}/config.yml"
+    then
+        echo '--no-random-sleep-on-renew'
+    fi
+}
+
 function updateLetsEncrypt() {
     if [ -d "${OUTPUT_DIR}/letsencrypt/live" ]
     then
         docker pull certbot/certbot
         docker run -i --rm --name certbot -p 443:443 -p 80:80 \
             -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
-            renew --logs-dir /etc/letsencrypt/logs
+            renew ${preventLetsEncryptRandomSleepOnRenew} --logs-dir /etc/letsencrypt/logs
     fi
 }
 
@@ -180,7 +188,7 @@ function forceUpdateLetsEncrypt() {
         docker pull certbot/certbot
         docker run -i --rm --name certbot -p 443:443 -p 80:80 \
             -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
-            renew --logs-dir /etc/letsencrypt/logs --force-renew
+            renew ${preventLetsEncryptRandomSleepOnRenew} --logs-dir /etc/letsencrypt/logs --force-renew
     fi
 }
 


### PR DESCRIPTION
## Type of change
New feature development


## Objective
This allows for self-hosted Bitwarden administrators to define that certbot should not sleep randomly on renewals. This was previously reported in bitwarden/server#415, but LE has since introduced the --no-random-sleep-on-renew flag to prevent the delay.

Prior PR bitwarden/server#1766 for previous effort. Do the `util/Setup/Configuration.cs` code changes from this commit still need to be committed there to support this configuration option?
