### PR TITLE
update ::set-output to latest

### DIFF
--- a/.github/workflows/release-digital-ocean.yml
+++ b/.github/workflows/release-digital-ocean.yml
@@ -36,7 +36,7 @@ jobs:
           do
             VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
             echo "::add-mask::$VALUE"
-            echo "::set-output name=$i::$VALUE"
+            echo "$i=$VALUE" >> $GITHUB_OUTPUT
           done
 
       - name: Set version from version.json
@@ -45,7 +45,7 @@ jobs:
           VERSION=$(grep '^ *"coreVersion":' version.json \
             | awk -F\: '{ print $2 }' \
             | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build Digital Ocean Image
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         id: branch
         run: |
           BRANCH_NAME=$(basename ${{ github.ref }})
-          echo "::set-output name=branch-name::$BRANCH_NAME"
+          echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
 
   release:
@@ -108,7 +108,7 @@ jobs:
           do
             VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
             echo "::add-mask::$VALUE"
-            echo "::set-output name=$i::$VALUE"
+            echo "$i=$VALUE" >> $GITHUB_OUTPUT
           done
 
       - name: Upload version.json to S3 bucket
@@ -181,7 +181,7 @@ jobs:
           SERVICE_NAME=$(echo "${{ matrix.service_name }}" | awk '{print tolower($0)}')
           echo "Matrix name: ${{ matrix.service_name }}"
           echo "SERVICE_NAME: $SERVICE_NAME"
-          echo "::set-output name=service_name::$SERVICE_NAME"
+          echo "service_name=$SERVICE_NAME" >> $GITHUB_OUTPUT
 
       ########## DockerHub ##########
       - name: Setup DCT
@@ -194,14 +194,12 @@ jobs:
       - name: Pull versioned image
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
-        run: |
-          docker pull bitwarden/$SERVICE_NAME:$_RELEASE_VERSION
+        run: docker pull bitwarden/$SERVICE_NAME:$_RELEASE_VERSION
 
       - name: Tag latest
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
-        run: |
-          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION bitwarden/$SERVICE_NAME:latest
+        run: docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION bitwarden/$SERVICE_NAME:latest
 
       - name: Push latest image
         env:
@@ -232,15 +230,13 @@ jobs:
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
+        run: docker tag bitwarden/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
 
       - name: Push version and latest image
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker push $REGISTRY/$SERVICE_NAME:latest
+        run: docker push $REGISTRY/$SERVICE_NAME:latest
 
       - name: Log out of Docker
         run: docker logout
@@ -279,7 +275,7 @@ jobs:
           SERVICE_NAME=$(echo "${{ matrix.service_name }}" | awk '{print tolower($0)}')
           echo "Matrix name: ${{ matrix.service_name }}"
           echo "SERVICE_NAME: $SERVICE_NAME"
-          echo "::set-output name=service_name::$SERVICE_NAME"
+          echo "service_name=$SERVICE_NAME" >> $GITHUB_OUTPUT
 
       ########## ACR ##########
       - name: Login to Azure - QA Subscription
@@ -294,22 +290,19 @@ jobs:
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker pull $REGISTRY/$SERVICE_NAME:$_RELEASE_VERSION
+        run: docker pull $REGISTRY/$SERVICE_NAME:$_RELEASE_VERSION
 
       - name: Tag latest
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker tag $REGISTRY/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
+        run: docker tag $REGISTRY/$SERVICE_NAME:$_RELEASE_VERSION $REGISTRY/$SERVICE_NAME:latest
 
       - name: Push version and latest image
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
           REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker push $REGISTRY/$SERVICE_NAME:latest
+        run: docker push $REGISTRY/$SERVICE_NAME:latest
 
       - name: Log out of Docker
         run: docker logout

--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -31,16 +31,16 @@ jobs:
           do
             VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
             echo "::add-mask::$VALUE"
-            echo "::set-output name=$i::$VALUE"
+            echo "$i=$VALUE" >> $GITHUB_OUTPUT
           done
 
       - name: Set tag name
         id: tag-name
         run: |
           if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
-            echo "::set-output name=value::${{ github.event.inputs.release_tag }}"
+            echo "value=${{ github.event.inputs.release_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=value::$GITHUB_REF_NAME"
+            echo "value=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
           fi
 
       - name: Update Bitwarden Script PowerShell Link

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -39,9 +39,9 @@ jobs:
           echo "Latest Core Version: $LATEST_CORE_VERSION"
           if [ "$CORE_VERSION" != "$LATEST_CORE_VERSION" ]; then
             echo "Needs Core update!"
-            echo "::set-output name=update::1"
+            echo "update=1" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=update::0"
+            echo "update=0" >> $GITHUB_OUTPUT
           fi
 
       - name: Get Latest Web Version
@@ -63,9 +63,9 @@ jobs:
           echo "Latest Web Version: $LATEST_WEB_VERSION"
           if [ "$WEB_VERSION" != "$LATEST_WEB_VERSION" ]; then
             echo "Needs Web update!"
-            echo "::set-output name=update::1"
+            echo "update=1" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=update::0"
+            echo "update=0" >> $GITHUB_OUTPUT
           fi
 
       - name: Get Latest Key Connector Version
@@ -85,9 +85,9 @@ jobs:
           echo "Latest Key Connector Version: $LATEST_KEY_CONNECTOR_VERSION"
           if [ "$KEY_CONNECTOR_VERSION" != "$LATEST_KEY_CONNECTOR_VERSION" ]; then
             echo "Needs Key Connector update!"
-            echo "::set-output name=update::1"
+            echo "update=1" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=update::0"
+            echo "update=0" >> $GITHUB_OUTPUT
           fi
 
 


### PR DESCRIPTION
## Objective

This PR is updating the set output command in the workflow to the latest method, the previous is deprecated.
Changes Job steps with one line of code but taking two lines to one line.

## Code changes
Change the ::set-output command to Github's environment variable $GITHUB_OUTPUT

* **file.ext:** Description of what was changed and why
- .github/workflows/*.yaml files
