### PR TITLE
[DEVOPS-1265] - Update GitHub secret name

### DIFF
--- a/.github/workflows/release-digital-ocean.yml
+++ b/.github/workflows/release-digital-ocean.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Login to Azure - Prod Subscription
         uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
         with:
-          creds: ${{ secrets.AZURE_CI_KV_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPLE }}
 
       - name: Retrieve secrets
         id: retrieve-secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Login to Azure
         uses: Azure/login@ec3c14589bd3e9312b3cc8c41e6860e258df9010
         with:
-          creds: ${{ secrets.AZURE_CI_KV_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPLE }}
 
       - name: Retrieve secrets
         id: retrieve-secrets
@@ -172,7 +172,7 @@ jobs:
         id: setup-dct
         uses: bitwarden/gh-actions/setup-docker-trust@a8c384a05a974c05c48374c818b004be221d43ff
         with:
-          azure-creds: ${{ secrets.AZURE_CI_KV_CREDENTIALS }}
+          azure-creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPLE }}
           azure-keyvault-name: "bitwarden-ci"
 
       - name: Pull versioned image

--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Login to Azure - Prod Subscription
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
-          creds: ${{ secrets.AZURE_CI_KV_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPLE }}
 
       - name: Retrieve secrets
         id: retrieve-secrets


### PR DESCRIPTION
Updates the GitHub secret name to use the new `AZURE_KV_CI_SERVICE_PRINCIPLE` secret.