### PR TITLE
Update Digital Ocean VM size

### DIFF
--- a/.github/workflows/release-digital-ocean.yml
+++ b/.github/workflows/release-digital-ocean.yml
@@ -53,14 +53,14 @@ jobs:
           packer build marketplace-image.pkr.hcl
 
       - name: Install doctl
-        if: false
+        if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
         uses: digitalocean/action-doctl@ba7726ed64a9c5eb774152b1ea03bf67ee81ad6e # v2.3.0
         with:
           token: ${{ steps.retrieve-secrets.outputs.digital-ocean-api-key }}
 
       - name: Digital Ocean Image Cleanup
         working-directory: ./DigitalOceanMarketplace
-        if: false
+        if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
         run: |
           # Get the ID from the snapshot build.
           DO_ARTIFACT=$(jq -r '.builds[-1].artifact_id' manifest.json | cut -d ":" -f2)

--- a/.github/workflows/release-digital-ocean.yml
+++ b/.github/workflows/release-digital-ocean.yml
@@ -53,13 +53,14 @@ jobs:
           packer build marketplace-image.pkr.hcl
 
       - name: Install doctl
+        if: false
         uses: digitalocean/action-doctl@ba7726ed64a9c5eb774152b1ea03bf67ee81ad6e # v2.3.0
         with:
           token: ${{ steps.retrieve-secrets.outputs.digital-ocean-api-key }}
 
       - name: Digital Ocean Image Cleanup
         working-directory: ./DigitalOceanMarketplace
-        if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
+        if: false
         run: |
           # Get the ID from the snapshot build.
           DO_ARTIFACT=$(jq -r '.builds[-1].artifact_id' manifest.json | cut -d ":" -f2)

--- a/DigitalOceanMarketplace/marketplace-image.pkr.hcl
+++ b/DigitalOceanMarketplace/marketplace-image.pkr.hcl
@@ -46,7 +46,7 @@ source "digitalocean" "bitwarden_self_host" {
   api_token     = "${var.do_token}"
   image         = "ubuntu-22-04-x64"
   region        = "nyc3"
-  size          = "s-1vcpu-1gb"
+  size          = "s-1vcpu-2gb"
   snapshot_name = "${local.image_name}"
   ssh_username  = "root"
 }


### PR DESCRIPTION
This PR updates the Digital Ocean VM size since VMs with less than 2 GB of RAM are not supported by MSSQL image.