### PR TITLE
[DEVOPS-1203] Update Release Flow

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -100,12 +100,12 @@ jobs:
       ########## Generate image tag and build Docker image ##########
       - name: Generate Docker image tag
         id: tag
+        env:
+          SERVER_BRANCH: ${{ steps.server-branch-name.outputs.server_branch }}
         run: |
-          IMAGE_TAG=$(echo "${GITHUB_REF:11}" | sed "s#/#-#g")  # slash safe branch name
+          IMAGE_TAG=$(echo "${SERVER_BRANCH}" | sed "s#/#-#g")  # slash safe branch name
           if [[ "$IMAGE_TAG" == "master" ]]; then
             IMAGE_TAG=dev
-          elif [[ "$IMAGE_TAG" == "rc" ]] || [[ "$IMAGE_TAG" == "hotfix-rc" ]]; then
-            IMAGE_TAG=beta
           fi
 
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -32,6 +32,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           SERVER_BRANCH: ${{ github.event.inputs.server_branch }}
         run: |
+          SERVER_BRANCH=${SERVER_BRANCH:11}
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "server_branch=$SERVER_BRANCH" >> $GITHUB_OUTPUT
             echo "Branch: $SERVER_BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,3 +313,91 @@ jobs:
 
       - name: Log out of Docker
         run: docker logout
+
+  release-unified:
+    name: Release Self-host unified
+    runs-on: ubuntu-22.04
+    needs:
+      - setup
+      - release
+    env:
+      _RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+      _BRANCH_NAME: master
+    steps:
+
+      ########## DockerHub ##########
+      - name: Setup DCT
+        id: setup-dct
+        uses: bitwarden/gh-actions/setup-docker-trust@c86ced0dc8c9daeecf057a6333e6f318db9c5a2b
+        with:
+          azure-creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
+          azure-keyvault-name: "bitwarden-ci"
+
+      - name: Pull latest self-host image
+        run: |
+          if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
+            docker pull bitwarden/self-host:latest
+          else
+            docker pull bitwarden/self-host:$_BRANCH_NAME
+          fi
+
+      - name: Tag version and latest
+        run: |
+          if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
+            docker tag bitwarden/self-host:latest bitwarden/self-host:dryrun
+          else
+            docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:$_RELEASE_VERSION
+          fi
+
+      - name: Push version and latest image
+        if: ${{ github.event.inputs.release_type != 'Dry Run' && matrix.origin_docker_repo == 'bitwarden' }}
+        env:
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+        run: docker push bitwarden/self-host:$_RELEASE_VERSION
+
+      - name: Log out of Docker and disable Docker Notary
+        run: |
+          docker logout
+          echo "DOCKER_CONTENT_TRUST=0" >> $GITHUB_ENV
+
+      ########## ACR PROD ##########
+      - name: Login to Azure - PROD Subscription
+        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Login to Azure ACR
+        run: az acr login -n bitwardenprod
+
+      - name: Pull latest project image
+        env:
+          REGISTRY: bitwardenprod.azurecr.io
+        run: |
+          if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
+            docker pull $REGISTRY/self-host:dev
+          else
+            docker pull $REGISTRY/self-host:$_BRANCH_NAME
+          fi
+
+      - name: Tag version and latest
+        env:
+          REGISTRY: bitwardenprod.azurecr.io
+        run: |
+          if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
+            docker tag $REGISTRY/self-host:dev $REGISTRY/self-host:dryrun
+          else
+            docker tag $REGISTRY/self-host:$_BRANCH_NAME $REGISTRY/self-host:$_RELEASE_VERSION
+            docker tag $REGISTRY/self-host:$_BRANCH_NAME $REGISTRY/self-host:latest
+          fi
+
+      - name: Push version and latest image
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          REGISTRY: bitwardenprod.azurecr.io
+        run: |
+          docker push $REGISTRY/self-host:$_RELEASE_VERSION
+          docker push $REGISTRY/self-host:latest
+
+      - name: Log out of Docker
+        run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,8 +344,19 @@ jobs:
       - release
     env:
       _RELEASE_VERSION: ${{ github.event.inputs.release_version }}-beta # TODO: remove `-beta` after GA
-      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
     steps:
+
+      - name: Get tag
+        id: get-tag
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+        run: |
+          last_number=$(echo $RELEASE_VERSION | cut -d '.' -f 3)
+          if [ $last_number -eq 0 ]; then
+            echo "branch_name=rc" >> $GITHUB_OUTPUT
+          else
+            echo "branch_name=hotfix-rc" >> $GITHUB_OUTPUT
+          fi
 
       ########## DockerHub ##########
       - name: Setup DCT
@@ -364,6 +375,8 @@ jobs:
           fi
 
       - name: Tag version and latest
+        env:
+          _BRANCH_NAME: ${{ steps.setup.outputs.branch_name }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker tag bitwarden/self-host:dev bitwarden/self-host:dryrun
@@ -398,6 +411,7 @@ jobs:
       - name: Pull latest project image
         env:
           REGISTRY: bitwardenprod.azurecr.io
+          _BRANCH_NAME: ${{ steps.setup.outputs.branch_name }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker pull $REGISTRY/self-host:dev
@@ -408,6 +422,7 @@ jobs:
       - name: Tag version and latest
         env:
           REGISTRY: bitwardenprod.azurecr.io
+          _BRANCH_NAME: ${{ steps.setup.outputs.branch_name }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker tag $REGISTRY/self-host:dev $REGISTRY/self-host:dryrun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       _CORE_RELEASE_TAG: ${{ steps.set-tags.outputs.CORE_RELEASE_TAG }}
     steps:
       - name: Branch check
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: |
           if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
             echo "==================================="
@@ -74,20 +75,21 @@ jobs:
         with:
           ref: master
 
-      # - name: Create release
-      #   uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
-      #   with:
-      #     artifacts: 'bitwarden.sh,
-      #                 run.sh,
-      #                 bitwarden.ps1,
-      #                 run.ps1,
-      #                 version.json'
-      #     commit: ${{ github.sha }}
-      #     tag: "v${{ github.event.inputs.release_version }}"
-      #     name: "Version ${{ github.event.inputs.release_version }}"
-      #     body: "<insert release notes here>"
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     draft: true
+      - name: Create release
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
+        with:
+          artifacts: 'bitwarden.sh,
+                      run.sh,
+                      bitwarden.ps1,
+                      run.ps1,
+                      version.json'
+          commit: ${{ github.sha }}
+          tag: "v${{ github.event.inputs.release_version }}"
+          name: "Version ${{ github.event.inputs.release_version }}"
+          body: "<insert release notes here>"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
 
   release-version:
     name: Upload version.json
@@ -118,28 +120,30 @@ jobs:
             r2-bitwarden-selfhost-version-bucket-name,
             cf-prod-account"
 
-      # - name: Upload version.json to S3 bucket
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
-      #     AWS_DEFAULT_REGION: 'us-west-2'
-      #     AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
-      #   run: |
-      #     aws s3 cp version.json $AWS_S3_BUCKET_NAME \
-      #     --acl "public-read" \
-      #     --quiet
+      - name: Upload version.json to S3 bucket
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
+          AWS_DEFAULT_REGION: 'us-west-2'
+          AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
+        run: |
+          aws s3 cp version.json $AWS_S3_BUCKET_NAME \
+          --acl "public-read" \
+          --quiet
 
-      # - name: Upload version.json to R2 bucket
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.r2-electron-access-id }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.r2-electron-access-key }}
-      #     AWS_DEFAULT_REGION: 'us-east-1'
-      #     AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.r2-bitwarden-selfhost-version-bucket-name }}
-      #     CF_ACCOUNT: ${{ steps.retrieve-secrets.outputs.cf-prod-account }}
-      #   run: |
-      #     aws s3 cp version.json $AWS_S3_BUCKET_NAME \
-      #     --quiet \
-      #     --endpoint-url https://${CF_ACCOUNT}.r2.cloudflarestorage.com
+      - name: Upload version.json to R2 bucket
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.r2-electron-access-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.r2-electron-access-key }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+          AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.r2-bitwarden-selfhost-version-bucket-name }}
+          CF_ACCOUNT: ${{ steps.retrieve-secrets.outputs.cf-prod-account }}
+        run: |
+          aws s3 cp version.json $AWS_S3_BUCKET_NAME \
+          --quiet \
+          --endpoint-url https://${CF_ACCOUNT}.r2.cloudflarestorage.com
 
   tag-docker-latest:
     name: Tag Docker images latest
@@ -217,16 +221,17 @@ jobs:
           RELEASE_TAG: ${{ steps.setup.outputs.release_tag }}
         run: docker tag bitwarden/$PROJECT_NAME:$RELEASE_TAG bitwarden/$PROJECT_NAME:latest
 
-      # - name: Push latest image
-      #   env:
-      #     DOCKER_CONTENT_TRUST: 1
-      #     DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-      #     PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-      #   run: |
-      #     if [ "$PROJECT_NAME" == "scim" ]; then
-      #       export DOCKER_CONTENT_TRUST=0
-      #     fi
-      #     docker push bitwarden/$PROJECT_NAME:latest
+      - name: Push latest image
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
+        run: |
+          if [ "$PROJECT_NAME" == "scim" ]; then
+            export DOCKER_CONTENT_TRUST=0
+          fi
+          docker push bitwarden/$PROJECT_NAME:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -249,11 +254,12 @@ jobs:
           RELEASE_TAG: ${{ steps.setup.outputs.release_tag }}
         run: docker tag bitwarden/$PROJECT_NAME:$RELEASE_TAG $REGISTRY/$PROJECT_NAME:latest
 
-      # - name: Push latest image
-      #   env:
-      #     PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-      #     REGISTRY: bitwardenqa.azurecr.io
-      #   run: docker push $REGISTRY/$PROJECT_NAME:latest
+      - name: Push latest image
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
+          REGISTRY: bitwardenqa.azurecr.io
+        run: docker push $REGISTRY/$PROJECT_NAME:latest
 
       - name: Log out of Docker
         run: docker logout
@@ -315,11 +321,12 @@ jobs:
           REGISTRY: bitwardenprod.azurecr.io
         run: docker tag $REGISTRY/$PROJECT_NAME:$_RELEASE_TAG $REGISTRY/$PROJECT_NAME:latest
 
-      # - name: Push latest image
-      #   env:
-      #     PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-      #     REGISTRY: bitwardenprod.azurecr.io
-      #   run: docker push $REGISTRY/$PROJECT_NAME:latest
+      - name: Push latest image
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
+          REGISTRY: bitwardenprod.azurecr.io
+        run: docker push $REGISTRY/$PROJECT_NAME:latest
 
       - name: Log out of Docker
         run: docker logout
@@ -359,12 +366,12 @@ jobs:
             docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:$_RELEASE_VERSION
           fi
 
-      # - name: Push version and latest image
-      #   if: ${{ github.event.inputs.release_type != 'Dry Run' && matrix.origin_docker_repo == 'bitwarden' }}
-      #   env:
-      #     DOCKER_CONTENT_TRUST: 1
-      #     DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-      #   run: docker push bitwarden/self-host:$_RELEASE_VERSION
+      - name: Push version and latest image
+        if: ${{ github.event.inputs.release_type != 'Dry Run' && matrix.origin_docker_repo == 'bitwarden' }}
+        env:
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+        run: docker push bitwarden/self-host:$_RELEASE_VERSION
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -401,13 +408,13 @@ jobs:
             docker tag $REGISTRY/self-host:$_BRANCH_NAME $REGISTRY/self-host:latest
           fi
 
-      # - name: Push version and latest image
-      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-      #   env:
-      #     REGISTRY: bitwardenprod.azurecr.io
-      #   run: |
-      #     docker push $REGISTRY/self-host:$_RELEASE_VERSION
-      #     docker push $REGISTRY/self-host:latest
+      - name: Push version and latest image
+        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+        env:
+          REGISTRY: bitwardenprod.azurecr.io
+        run: |
+          docker push $REGISTRY/self-host:$_RELEASE_VERSION
+          docker push $REGISTRY/self-host:latest
 
       - name: Log out of Docker
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,7 @@ jobs:
       - name: Pull latest self-host image
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker pull bitwarden/self-host:latest
+            docker pull bitwarden/self-host:dev
           else
             docker pull bitwarden/self-host:$_BRANCH_NAME
           fi
@@ -361,7 +361,7 @@ jobs:
       - name: Tag version and latest
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker tag bitwarden/self-host:latest bitwarden/self-host:dryrun
+            docker tag bitwarden/self-host:dev bitwarden/self-host:dryrun
           else
             docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:$_RELEASE_VERSION
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 ---
 name: Release
+run-name: Release v${{ github.event.inputs.release_version }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,15 @@ on:
       release_version:
         description: "Release Version"
         required: true
+      release_type:
+        description: "Release Options"
+        required: true
+        default: "Initial Release"
+        type: choice
+        options:
+          - Initial Release
+          - Redeploy
+          - Dry Run
 
 jobs:
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
       - release
     env:
       _CORE_RELEASE_TAG: ${{ needs.setup.outputs._CORE_RELEASE_TAG }}
-      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
+      _BRANCH_NAME: master
     strategy:
       fail-fast: false
       matrix:
@@ -343,8 +343,8 @@ jobs:
       - setup
       - release
     env:
-      _RELEASE_VERSION: ${{ github.event.inputs.release_version }}-beta
-      _BRANCH_NAME: master
+      _RELEASE_VERSION: ${{ github.event.inputs.release_version }}-beta # TODO: remove `-beta` after GA
+      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
     steps:
 
       ########## DockerHub ##########

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,20 +64,20 @@ jobs:
         with:
           ref: master
 
-      - name: Create release
-        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
-        with:
-          artifacts: 'bitwarden.sh,
-                      run.sh,
-                      bitwarden.ps1,
-                      run.ps1,
-                      version.json'
-          commit: ${{ github.sha }}
-          tag: "v${{ github.event.inputs.release_version }}"
-          name: "Version ${{ github.event.inputs.release_version }}"
-          body: "<insert release notes here>"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
+      # - name: Create release
+      #   uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
+      #   with:
+      #     artifacts: 'bitwarden.sh,
+      #                 run.sh,
+      #                 bitwarden.ps1,
+      #                 run.ps1,
+      #                 version.json'
+      #     commit: ${{ github.sha }}
+      #     tag: "v${{ github.event.inputs.release_version }}"
+      #     name: "Version ${{ github.event.inputs.release_version }}"
+      #     body: "<insert release notes here>"
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     draft: true
 
   release-version:
     name: Upload version.json
@@ -108,28 +108,28 @@ jobs:
             r2-bitwarden-selfhost-version-bucket-name,
             cf-prod-account"
 
-      - name: Upload version.json to S3 bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
-          AWS_DEFAULT_REGION: 'us-west-2'
-          AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
-        run: |
-          aws s3 cp version.json $AWS_S3_BUCKET_NAME \
-          --acl "public-read" \
-          --quiet
+      # - name: Upload version.json to S3 bucket
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
+      #     AWS_DEFAULT_REGION: 'us-west-2'
+      #     AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
+      #   run: |
+      #     aws s3 cp version.json $AWS_S3_BUCKET_NAME \
+      #     --acl "public-read" \
+      #     --quiet
 
-      - name: Upload version.json to R2 bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.r2-electron-access-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.r2-electron-access-key }}
-          AWS_DEFAULT_REGION: 'us-east-1'
-          AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.r2-bitwarden-selfhost-version-bucket-name }}
-          CF_ACCOUNT: ${{ steps.retrieve-secrets.outputs.cf-prod-account }}
-        run: |
-          aws s3 cp version.json $AWS_S3_BUCKET_NAME \
-          --quiet \
-          --endpoint-url https://${CF_ACCOUNT}.r2.cloudflarestorage.com
+      # - name: Upload version.json to R2 bucket
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.r2-electron-access-id }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.r2-electron-access-key }}
+      #     AWS_DEFAULT_REGION: 'us-east-1'
+      #     AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.r2-bitwarden-selfhost-version-bucket-name }}
+      #     CF_ACCOUNT: ${{ steps.retrieve-secrets.outputs.cf-prod-account }}
+      #   run: |
+      #     aws s3 cp version.json $AWS_S3_BUCKET_NAME \
+      #     --quiet \
+      #     --endpoint-url https://${CF_ACCOUNT}.r2.cloudflarestorage.com
 
   tag-docker-latest:
     name: Tag Docker images latest
@@ -207,16 +207,16 @@ jobs:
           RELEASE_TAG: ${{ steps.setup.outputs.release_tag }}
         run: docker tag bitwarden/$PROJECT_NAME:$RELEASE_TAG bitwarden/$PROJECT_NAME:latest
 
-      - name: Push latest image
-        env:
-          DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-        run: |
-          if [ "$PROJECT_NAME" == "scim" ]; then
-            export DOCKER_CONTENT_TRUST=0
-          fi
-          docker push bitwarden/$PROJECT_NAME:latest
+      # - name: Push latest image
+      #   env:
+      #     DOCKER_CONTENT_TRUST: 1
+      #     DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+      #     PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
+      #   run: |
+      #     if [ "$PROJECT_NAME" == "scim" ]; then
+      #       export DOCKER_CONTENT_TRUST=0
+      #     fi
+      #     docker push bitwarden/$PROJECT_NAME:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -239,11 +239,11 @@ jobs:
           RELEASE_TAG: ${{ steps.setup.outputs.release_tag }}
         run: docker tag bitwarden/$PROJECT_NAME:$RELEASE_TAG $REGISTRY/$PROJECT_NAME:latest
 
-      - name: Push latest image
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenqa.azurecr.io
-        run: docker push $REGISTRY/$PROJECT_NAME:latest
+      # - name: Push latest image
+      #   env:
+      #     PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
+      #     REGISTRY: bitwardenqa.azurecr.io
+      #   run: docker push $REGISTRY/$PROJECT_NAME:latest
 
       - name: Log out of Docker
         run: docker logout
@@ -305,11 +305,11 @@ jobs:
           REGISTRY: bitwardenprod.azurecr.io
         run: docker tag $REGISTRY/$PROJECT_NAME:$_RELEASE_TAG $REGISTRY/$PROJECT_NAME:latest
 
-      - name: Push latest image
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenprod.azurecr.io
-        run: docker push $REGISTRY/$PROJECT_NAME:latest
+      # - name: Push latest image
+      #   env:
+      #     PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
+      #     REGISTRY: bitwardenprod.azurecr.io
+      #   run: docker push $REGISTRY/$PROJECT_NAME:latest
 
       - name: Log out of Docker
         run: docker logout
@@ -349,12 +349,12 @@ jobs:
             docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:$_RELEASE_VERSION
           fi
 
-      - name: Push version and latest image
-        if: ${{ github.event.inputs.release_type != 'Dry Run' && matrix.origin_docker_repo == 'bitwarden' }}
-        env:
-          DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-        run: docker push bitwarden/self-host:$_RELEASE_VERSION
+      # - name: Push version and latest image
+      #   if: ${{ github.event.inputs.release_type != 'Dry Run' && matrix.origin_docker_repo == 'bitwarden' }}
+      #   env:
+      #     DOCKER_CONTENT_TRUST: 1
+      #     DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+      #   run: docker push bitwarden/self-host:$_RELEASE_VERSION
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -391,13 +391,13 @@ jobs:
             docker tag $REGISTRY/self-host:$_BRANCH_NAME $REGISTRY/self-host:latest
           fi
 
-      - name: Push version and latest image
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          REGISTRY: bitwardenprod.azurecr.io
-        run: |
-          docker push $REGISTRY/self-host:$_RELEASE_VERSION
-          docker push $REGISTRY/self-host:latest
+      # - name: Push version and latest image
+      #   if: ${{ github.event.inputs.release_type != 'Dry Run' }}
+      #   env:
+      #     REGISTRY: bitwardenprod.azurecr.io
+      #   run: |
+      #     docker push $REGISTRY/self-host:$_RELEASE_VERSION
+      #     docker push $REGISTRY/self-host:latest
 
       - name: Log out of Docker
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 ---
 name: Release
-run-name: Release v${{ github.event.inputs.release_version }}
+run-name: Release ${{ github.event.inputs.release_type }} v${{ github.event.inputs.release_version }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,7 +355,7 @@ jobs:
           azure-creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
           azure-keyvault-name: "bitwarden-ci"
 
-      - name: Pull latest self-host image
+      - name: Pull self-host image
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker pull bitwarden/self-host:dev
@@ -369,6 +369,7 @@ jobs:
             docker tag bitwarden/self-host:dev bitwarden/self-host:dryrun
           else
             docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:$_RELEASE_VERSION
+            # docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:latest # TODO: uncomment this line after GA
           fi
 
       - name: Push version and latest image
@@ -376,7 +377,9 @@ jobs:
         env:
           DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-        run: docker push bitwarden/self-host:$_RELEASE_VERSION
+        run: |
+          docker push bitwarden/self-host:$_RELEASE_VERSION
+          # docker push bitwarden/self-host:latest # TODO: uncomment this line after GA
 
       - name: Log out of Docker and disable Docker Notary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,10 @@ on:
       release_type:
         description: "Release Options"
         required: true
-        default: "Initial Release"
+        default: "Release"
         type: choice
         options:
-          - Initial Release
-          - Redeploy
+          - Release
           - Dry Run
 
 jobs:
@@ -25,6 +24,7 @@ jobs:
     outputs:
       _WEB_RELEASE_TAG: ${{ steps.set-tags.outputs.WEB_RELEASE_TAG }}
       _CORE_RELEASE_TAG: ${{ steps.set-tags.outputs.CORE_RELEASE_TAG }}
+      branch-name: ${{ steps.branch.outputs.branch-name }}
     steps:
       - name: Branch check
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
@@ -64,6 +64,11 @@ jobs:
           echo "WEB_RELEASE_TAG=$WEB" >> $GITHUB_OUTPUT
           echo "CORE_RELEASE_TAG=$CORE" >> $GITHUB_OUTPUT
 
+      - name: Get branch name
+        id: branch
+        run: |
+          BRANCH_NAME=$(basename ${{ github.ref }})
+          echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
   release:
     name: Create GitHub Release
@@ -153,7 +158,7 @@ jobs:
       - release
     env:
       _CORE_RELEASE_TAG: ${{ needs.setup.outputs._CORE_RELEASE_TAG }}
-      _BRANCH_NAME: master
+      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
     strategy:
       fail-fast: false
       matrix:
@@ -338,7 +343,7 @@ jobs:
       - setup
       - release
     env:
-      _RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+      _RELEASE_VERSION: ${{ github.event.inputs.release_version }}-beta
       _BRANCH_NAME: master
     steps:
 


### PR DESCRIPTION
Update bitwarden unified release flow.

For now it tags the image from `rc` or `hotfix-rc` branches as `[version]-beta` e.g.: `2023.5.0-beta`. There are `TODO:` comments in places where values needs to be changed or lines to be uncommented before GA.