### PR TITLE
Fix checkout repo step in Build Unified workflow

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -30,7 +30,15 @@ jobs:
     name: Build Docker image
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repo
+      - name: Checkout Repository - workflow_call
+        if: ${{ github.event_name == 'workflow_call' }}
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          repository: bitwarden/self-host
+          ref: master
+
+      - name: Checkout Repository - workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Get server branch to checkout


### PR DESCRIPTION
GitHub does not checkout the workflow's repository if it is called.  In this case, the checkout step was cloning the `server` repository when it was called instead of the `self-host` repository.  This led to the `docker-unified` folder being missing.