### PR TITLE
DEVOPS-1446 - Fix if logic for checkout step in Build Unified workflow

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -9,8 +9,6 @@ on:
   workflow_call:
     inputs:
       server_branch:
-        description: "Server branch name to deploy (examples: 'master', 'rc', 'feature/sm')"
-        required: true
         type: string
         default: master
       is_workflow_call:
@@ -20,7 +18,6 @@ on:
     inputs:
       server_branch:
         description: "Server branch name to deploy (examples: 'master', 'rc', 'feature/sm')"
-        required: true
         type: string
         default: master
   pull_request:
@@ -41,7 +38,7 @@ jobs:
           ref: master
 
       - name: Checkout Repository - workflow_dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ inputs.is_workflow_call != true }}
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Get server branch to checkout


### PR DESCRIPTION
This PR fixes the checkout step for `workflow_dispatch` from triggering when called using `workflow_call`.  Removed the `required` keys for inputs as they are not needed when specifying the `default` key.