### PR TITLE
Fix build and release logic for Unified

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -119,6 +119,8 @@ jobs:
           IMAGE_TAG=$(echo "${SERVER_BRANCH}" | sed "s#/#-#g")  # slash safe branch name
           if [[ "${IMAGE_TAG}" == "master" ]]; then
             IMAGE_TAG=dev
+          elif [[ ("{IMAGE_TAG}" == "rc") || ("${IMAGE_TAG}" == "hotfix-rc") ]]; then
+            IMAGE_TAG=beta
           fi
 
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,18 +338,6 @@ jobs:
     env:
       _RELEASE_VERSION: ${{ github.event.inputs.release_version }}-beta # TODO: remove `-beta` after GA
     steps:
-      - name: Setup
-        id: setup
-        env:
-          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-        run: |
-          last_number=$(echo $RELEASE_VERSION | cut -d '.' -f 3)
-          if [ $last_number -eq 0 ]; then
-            echo "branch_name=rc" >> $GITHUB_OUTPUT
-          else
-            echo "branch_name=hotfix-rc" >> $GITHUB_OUTPUT
-          fi
-
       ########## DockerHub ##########
       - name: Setup DCT
         id: setup-dct
@@ -359,24 +347,20 @@ jobs:
           azure-keyvault-name: "bitwarden-ci"
 
       - name: Pull self-host image
-        env:
-          _BRANCH_NAME: ${{ steps.setup.outputs.branch_name }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker pull bitwarden/self-host:dev
           else
-            docker pull bitwarden/self-host:$_BRANCH_NAME
+            docker pull bitwarden/self-host:beta
           fi
 
       - name: Tag version and latest
-        env:
-          _BRANCH_NAME: ${{ steps.setup.outputs.branch_name }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker tag bitwarden/self-host:dev bitwarden/self-host:dryrun
           else
-            docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:$_RELEASE_VERSION
-            # docker tag bitwarden/self-host:$_BRANCH_NAME bitwarden/self-host:latest # TODO: uncomment this line after GA
+            docker tag bitwarden/self-host:beta bitwarden/self-host:$_RELEASE_VERSION
+            # docker tag bitwarden/self-host:beta bitwarden/self-host:latest # TODO: uncomment this line after GA
           fi
 
       - name: Push version and latest image
@@ -405,24 +389,22 @@ jobs:
       - name: Pull latest project image
         env:
           REGISTRY: bitwardenprod.azurecr.io
-          _BRANCH_NAME: ${{ steps.setup.outputs.branch_name }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker pull $REGISTRY/self-host:dev
           else
-            docker pull $REGISTRY/self-host:$_BRANCH_NAME
+            docker pull $REGISTRY/self-host:beta
           fi
 
       - name: Tag version and latest
         env:
           REGISTRY: bitwardenprod.azurecr.io
-          _BRANCH_NAME: ${{ steps.setup.outputs.branch_name }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
             docker tag $REGISTRY/self-host:dev $REGISTRY/self-host:dryrun
           else
-            docker tag $REGISTRY/self-host:$_BRANCH_NAME $REGISTRY/self-host:$_RELEASE_VERSION
-            docker tag $REGISTRY/self-host:$_BRANCH_NAME $REGISTRY/self-host:latest
+            docker tag $REGISTRY/self-host:beta $REGISTRY/self-host:$_RELEASE_VERSION
+            docker tag $REGISTRY/self-host:beta $REGISTRY/self-host:latest
           fi
 
       - name: Push version and latest image


### PR DESCRIPTION
## `build-unified.yml`

When the `build-unified.yml` workflow was called from the `server` repository on the `rc` branch, it was setting the `IMAGE_TAG` as `rc`.  This led to the `Generate tag list` step never generating a tag for Docker Hub.  I added the `elif` statement to the `Generate Docker image tag` step to fix this issue by setting the tag to `beta`.

## `release.yml`

Inside of the `release-unified` job, it was trying to pull `bitwarden/self-host:rc` which has never existed on Docker Hub.  We need to pull the `beta` tag and release that as `bitwarden/self-host:v202X.X.X-beta`. Changing all of the pull and tag steps to use the `beta` tag fixes this issue.

In the future, when we release Unified to GA we will need to update both workflows to use our standard release/tagging processes at that time.