### PR TITLE
[PM-3019] Add Proxy Passthrough

### DIFF
--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -134,6 +134,12 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
   }
+
+  location /notifications/anonymous-hub {
+    proxy_pass http://localhost:5006/anonymous-hub;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+  }
 {{/if}}
 {{#if (String.Equal env.BW_ENABLE_EVENTS "true")}}
 


### PR DESCRIPTION
- Repeat proxy pass through for the anonymous-hub that enables Login with device

I believe this would fix bitwarden/server#3103, described in the PR, they are able to request it, receive it on their phone, confirm that request but their original client never gets told it completed. This would lend to 2 possible errors, their confirming client is never actually telling the server that it was confirmed or the server is not able to notify the originating client of the success. The following log makes me think the originating client isn't actually able to connect to the anonymous-hub (or even see it). Going by this config we have special rules for the existing `hub` but not this new one.

```
Error: WebSocket failed to connect. The connection could not be found on the server, either the endpoint may not be a SignalR endpoint, the connection ID is not present on the server, or there is a proxy blocking WebSockets. If you have multiple servers check that sticky sessions are enabled.
```