### PR TITLE
[DEVOPS-1518] UPDATE: initial changes for ACR related work on all workflows

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -25,6 +25,9 @@ on:
       - ".github/workflows/build-self-host.yml"
       - "docker-unified/**"
 
+env:
+  _AZ_REGISTRY: bitwardenprod.azurecr.io
+
 jobs:
   build-docker:
     name: Build Docker image
@@ -75,14 +78,6 @@ jobs:
         uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
 
       ########## Login to Docker registries ##########
-      - name: Login to Azure - QA Subscription
-        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Login to Azure ACR
-        run: az acr login -n bitwardenqa
-
       - name: Login to Azure - Prod Subscription
         uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
         with:
@@ -132,9 +127,9 @@ jobs:
           IS_PUBLISH_BRANCH: ${{ env.is_publish_branch }}
         run: |
           if [[ ("${IMAGE_TAG}" == "dev" || "${IMAGE_TAG}" == "beta") && "${IS_PUBLISH_BRANCH}" == "true" ]]; then
-            echo "tags=bitwardenqa.azurecr.io/self-host:${IMAGE_TAG},bitwardenprod.azurecr.io/self-host:${IMAGE_TAG},bitwarden/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "tags=$_AZ_REGISTRY/self-host:${IMAGE_TAG},bitwarden/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           else
-            echo "tags=bitwardenqa.azurecr.io/self-host:${IMAGE_TAG},bitwardenprod.azurecr.io/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "tags=$_AZ_REGISTRY/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout server repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ on:
           - Release
           - Dry Run
 
+env:
+  _AZ_REGISTRY: bitwardenprod.azurecr.io
+
 jobs:
   setup:
     name: Setup
@@ -144,7 +147,7 @@ jobs:
           --endpoint-url https://${CF_ACCOUNT}.r2.cloudflarestorage.com
 
   tag-docker-latest:
-    name: Tag Docker images latest
+    name: Tag DockerHub images latest
     runs-on: ubuntu-22.04
     needs:
       - setup
@@ -170,7 +173,7 @@ jobs:
           - project_name: Sso
           - project_name: Web
             release_tag: ${{ needs.setup.outputs._WEB_RELEASE_TAG }}
-          - project_name: Scim
+          - project_name: Web-sh
     steps:
       - name: Print environment
         run: |
@@ -184,19 +187,27 @@ jobs:
         with:
           ref: master
 
+      - name: Login to Azure - Prod Subscription
+        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Login to Azure ACR
+        run: az acr login -n bitwardenprod
+
       - name: Setup project name and release tag
         id: setup
         run: |
           PROJECT_NAME=$(echo "${{ matrix.project_name }}" | awk '{print tolower($0)}')
           echo "Matrix name: ${{ matrix.project_name }}"
           echo "PROJECT_NAME: $PROJECT_NAME"
-          echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
+          echo "_PROJECT_NAME=$PROJECT_NAME" >> $GITHUB_ENV
 
           if [ -z "${{ matrix.release_tag }}" ]; then
             # Use core release tag by default.
-            echo "release_tag=$_CORE_RELEASE_TAG" >> $GITHUB_OUTPUT
+            echo "_RELEASE_TAG=$_CORE_RELEASE_TAG" >> $GITHUB_ENV
           else
-            echo "release_tag=${{ matrix.release_tag }}" >> $GITHUB_OUTPUT
+            echo "_RELEASE_TAG=${{ matrix.release_tag }}" >> $GITHUB_ENV
           fi
 
       ########## DockerHub ##########
@@ -208,126 +219,23 @@ jobs:
           azure-keyvault-name: "bitwarden-ci"
 
       - name: Pull versioned image
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          RELEASE_TAG: ${{ steps.setup.outputs.release_tag }}
-        run: docker pull bitwarden/$PROJECT_NAME:$RELEASE_TAG
+        run: docker pull $_AZ_REGISTRY/$_PROJECT_NAME:$RELEASE_TAG
 
       - name: Tag latest
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          RELEASE_TAG: ${{ steps.setup.outputs.release_tag }}
-        run: docker tag bitwarden/$PROJECT_NAME:$RELEASE_TAG bitwarden/$PROJECT_NAME:latest
+        run: docker tag $_AZ_REGISTRY/$_PROJECT_NAME:$RELEASE_TAG bitwarden/$_PROJECT_NAME:latest
 
       - name: Push latest image
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         env:
           DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
         run: |
-          if [ "$PROJECT_NAME" == "scim" ]; then
-            export DOCKER_CONTENT_TRUST=0
-          fi
-          docker push bitwarden/$PROJECT_NAME:latest
+          docker push bitwarden/$_PROJECT_NAME:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
           docker logout
           echo "DOCKER_CONTENT_TRUST=0" >> $GITHUB_ENV
-
-      ########## ACR ##########
-      - name: Login to Azure - QA Subscription
-        uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.6
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Login to Azure ACR
-        run: az acr login -n bitwardenqa
-
-      - name: Tag latest
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenqa.azurecr.io
-          RELEASE_TAG: ${{ steps.setup.outputs.release_tag }}
-        run: docker tag bitwarden/$PROJECT_NAME:$RELEASE_TAG $REGISTRY/$PROJECT_NAME:latest
-
-      - name: Push latest image
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenqa.azurecr.io
-        run: docker push $REGISTRY/$PROJECT_NAME:latest
-
-      - name: Log out of Docker
-        run: docker logout
-
-  tag-docker-web-latest:
-    name: Tag Web Docker images from bitwardenqa latest
-    runs-on: ubuntu-22.04
-    needs:
-      - setup
-      - release
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - project_name: web-sh
-          # - project_name: web-ee # Needs to be fixed in Web client release workflow.
-    env:
-      _RELEASE_TAG: ${{ needs.setup.outputs._WEB_RELEASE_TAG}}
-      _BRANCH_NAME: master
-    steps:
-      - name: Print environment
-        run: |
-          whoami
-          docker --version
-          echo "GitHub ref: $GITHUB_REF"
-          echo "GitHub event: $GITHUB_EVENT"
-
-      - name: Checkout repo
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          ref: master
-
-      - name: Setup project name
-        id: setup
-        run: |
-          PROJECT_NAME=$(echo "${{ matrix.project_name }}" | awk '{print tolower($0)}')
-          echo "Matrix name: ${{ matrix.project_name }}"
-          echo "PROJECT_NAME: $PROJECT_NAME"
-          echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
-
-      ########## ACR ##########
-      - name: Login to Azure - Prod Subscription
-        uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.6
-        with:
-          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
-
-      - name: Login to Azure ACR
-        run: az acr login -n bitwardenprod
-
-      - name: Pull versioned image
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenprod.azurecr.io
-        run: docker pull $REGISTRY/$PROJECT_NAME:$_RELEASE_TAG
-
-      - name: Tag latest
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenprod.azurecr.io
-        run: docker tag $REGISTRY/$PROJECT_NAME:$_RELEASE_TAG $REGISTRY/$PROJECT_NAME:latest
-
-      - name: Push latest image
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenprod.azurecr.io
-        run: docker push $REGISTRY/$PROJECT_NAME:latest
-
-      - name: Log out of Docker
-        run: docker logout
 
   release-unified:
     name: Release Self-host unified
@@ -349,18 +257,18 @@ jobs:
       - name: Pull self-host image
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker pull bitwarden/self-host:dev
+            docker pull $_AZ_REGISTRY/self-host:dev
           else
-            docker pull bitwarden/self-host:beta
+            docker pull $_AZ_REGISTRY/self-host:beta
           fi
 
       - name: Tag version and latest
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker tag bitwarden/self-host:dev bitwarden/self-host:dryrun
+            docker tag $_AZ_REGISTRY/self-host:dev bitwarden/self-host:dryrun
           else
-            docker tag bitwarden/self-host:beta bitwarden/self-host:$_RELEASE_VERSION
-            # docker tag bitwarden/self-host:beta bitwarden/self-host:latest # TODO: uncomment this line after GA
+            docker tag $_AZ_REGISTRY/self-host:beta bitwarden/self-host:$_RELEASE_VERSION
+            # docker tag $_AZ_REGISTRY/self-host:beta bitwarden/self-host:latest # TODO: uncomment this line after GA
           fi
 
       - name: Push version and latest image
@@ -387,33 +295,27 @@ jobs:
         run: az acr login -n bitwardenprod
 
       - name: Pull latest project image
-        env:
-          REGISTRY: bitwardenprod.azurecr.io
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker pull $REGISTRY/self-host:dev
+            docker pull $_AZ_REGISTRY/self-host:dev
           else
-            docker pull $REGISTRY/self-host:beta
+            docker pull $_AZ_REGISTRY/self-host:beta
           fi
 
       - name: Tag version and latest
-        env:
-          REGISTRY: bitwardenprod.azurecr.io
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker tag $REGISTRY/self-host:dev $REGISTRY/self-host:dryrun
+            docker tag $_AZ_REGISTRY/self-host:dev $_AZ_REGISTRY/self-host:dryrun
           else
-            docker tag $REGISTRY/self-host:beta $REGISTRY/self-host:$_RELEASE_VERSION
-            docker tag $REGISTRY/self-host:beta $REGISTRY/self-host:latest
+            docker tag $_AZ_REGISTRY/self-host:beta $_AZ_REGISTRY/self-host:$_RELEASE_VERSION
+            docker tag $_AZ_REGISTRY/self-host:beta $_AZ_REGISTRY/self-host:latest
           fi
 
       - name: Push version and latest image
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          REGISTRY: bitwardenprod.azurecr.io
         run: |
-          docker push $REGISTRY/self-host:$_RELEASE_VERSION
-          docker push $REGISTRY/self-host:latest
+          docker push $_AZ_REGISTRY/self-host:$_RELEASE_VERSION
+          docker push $_AZ_REGISTRY/self-host:latest
 
       - name: Log out of Docker
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,16 +293,6 @@ jobs:
           echo "DOCKER_CONTENT_TRUST=0" >> $GITHUB_ENV
 
       ########## ACR PROD ##########
-<<<<<<< HEAD
-=======
-      - name: Login to Azure - PROD Subscription
-        uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
-        with:
-          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
-
-      - name: Login to Azure ACR
-        run: az acr login -n bitwardenprod
->>>>>>> master
 
       - name: Pull latest project image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           --endpoint-url https://${CF_ACCOUNT}.r2.cloudflarestorage.com
 
   tag-docker-latest:
-    name: Tag DockerHub images latest
+    name: Tag Docker Hub images with release version and latest
     runs-on: ubuntu-22.04
     needs:
       - setup
@@ -188,12 +188,12 @@ jobs:
           ref: master
 
       - name: Login to Azure - Prod Subscription
-        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
+        uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
         with:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
       - name: Login to Azure ACR
-        run: az acr login -n bitwardenprod
+        run: az acr login -n ${_AZ_REGISTRY%.azurecr.io}
 
       - name: Setup project name and release tag
         id: setup
@@ -221,15 +221,19 @@ jobs:
       - name: Pull versioned image
         run: docker pull $_AZ_REGISTRY/$_PROJECT_NAME:$_RELEASE_TAG
 
-      - name: Tag latest
-        run: docker tag $_AZ_REGISTRY/$_PROJECT_NAME:$_RELEASE_TAG bitwarden/$_PROJECT_NAME:latest
+      - name: Tag release version and latest image
+        run: |
+          docker tag $_AZ_REGISTRY/$_PROJECT_NAME:$_RELEASE_TAG bitwarden/$_PROJECT_NAME:$_RELEASE_TAG
+          docker tag $_AZ_REGISTRY/$_PROJECT_NAME:$_RELEASE_TAG bitwarden/$_PROJECT_NAME:latest
 
-      - name: Push latest image
+      - name: Push release version and latest image
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         env:
           DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-        run: docker push bitwarden/$_PROJECT_NAME:latest
+        run: |
+          docker push bitwarden/$_PROJECT_NAME:$_RELEASE_TAG
+          docker push bitwarden/$_PROJECT_NAME:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -254,12 +258,12 @@ jobs:
           azure-keyvault-name: "bitwarden-ci"
 
       - name: Login to Azure - PROD Subscription
-        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
+        uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
         with:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
       - name: Login to Azure ACR
-        run: az acr login -n bitwardenprod
+        run: az acr login -n ${_AZ_REGISTRY%.azurecr.io}
 
       - name: Pull self-host image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,12 +168,12 @@ jobs:
           - project_name: MsSql
           - project_name: Nginx
           - project_name: Notifications
+          - project_name: Scim
           - project_name: Server
           - project_name: Setup
           - project_name: Sso
           - project_name: Web
             release_tag: ${{ needs.setup.outputs._WEB_RELEASE_TAG }}
-          - project_name: Web-sh
     steps:
       - name: Print environment
         run: |
@@ -219,18 +219,17 @@ jobs:
           azure-keyvault-name: "bitwarden-ci"
 
       - name: Pull versioned image
-        run: docker pull $_AZ_REGISTRY/$_PROJECT_NAME:$RELEASE_TAG
+        run: docker pull $_AZ_REGISTRY/$_PROJECT_NAME:$_RELEASE_TAG
 
       - name: Tag latest
-        run: docker tag $_AZ_REGISTRY/$_PROJECT_NAME:$RELEASE_TAG bitwarden/$_PROJECT_NAME:latest
+        run: docker tag $_AZ_REGISTRY/$_PROJECT_NAME:$_RELEASE_TAG bitwarden/$_PROJECT_NAME:latest
 
       - name: Push latest image
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         env:
           DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
-        run: |
-          docker push bitwarden/$_PROJECT_NAME:latest
+        run: docker push bitwarden/$_PROJECT_NAME:latest
 
       - name: Log out of Docker and disable Docker Notary
         run: |
@@ -253,6 +252,14 @@ jobs:
         with:
           azure-creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
           azure-keyvault-name: "bitwarden-ci"
+
+      - name: Login to Azure - PROD Subscription
+        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Login to Azure ACR
+        run: az acr login -n bitwardenprod
 
       - name: Pull self-host image
         run: |
@@ -286,13 +293,6 @@ jobs:
           echo "DOCKER_CONTENT_TRUST=0" >> $GITHUB_ENV
 
       ########## ACR PROD ##########
-      - name: Login to Azure - PROD Subscription
-        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf # v1.4.3
-        with:
-          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
-
-      - name: Login to Azure ACR
-        run: az acr login -n bitwardenprod
 
       - name: Pull latest project image
         run: |


### PR DESCRIPTION
- After the Server build workflow had stop pushing to DockerHub, we need the to update the Self-host release to pull from Prod ACR and tag and push to DockerHub for public consumption.

- **.github/workflows/build-unified.yml**: Self-host build pushes to DH and Prod ACR

- **.github/workflows/release.yml**: Self-host release is pulls latest tag from Prod ACR.

- **.github/workflows/release.yml**: Self-host release is pushing latest and 202X.X.X to DockerHub.