### PR TITLE
[DEVOPS-1566] - ADD: Migrator utility to DH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,7 @@ jobs:
           - project_name: Icons
           - project_name: Identity
           - project_name: MsSql
+          - project_name: MsSqlMigratorUtility
           - project_name: Nginx
           - project_name: Notifications
           - project_name: Scim


### PR DESCRIPTION
- Include the Migrator Utility as part of the BW stack getting pushed to Docker Hub.