### PR TITLE
Changing the  self-host workflow s3 bucket name to use a secret and not use the bucket name. 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-access-key }}
-          AWS_DEFAULT_REGION: 'us-west-2'
-          AWS_S3_BUCKET_NAME: 's3://public-s3-bitwarden-selfhost-version-artifact'
+          AWS_DEFAULT_REGION: 'us-east-1'
+          AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.aws-selfhost-version-bucket-name }}
         run: |
           aws s3 cp version.json $AWS_S3_BUCKET_NAME \
           --acl "public-read" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
           keyvault: "bitwarden-ci"
           secrets: "aws-selfhost-version-access-id,
             aws-selfhost-version-access-key,
+            aws-selfhost-version-bucket-name,
             r2-electron-access-id,
             r2-electron-access-key,
             r2-bitwarden-selfhost-version-bucket-name,


### PR DESCRIPTION
This is part of our effort to move the s3 buckets that are in Dev/Test to the Prod AWS accounts. This PR removes the bucket name for Self-Host and replaces it with a secret to match the setup for the client's workflow. Our main goal for this is to move production data to production accounts. 

With this change, the new bucket name is now held in the key vault in Azure, with a secret named aws-selfhost-version-bucket-name, which contains the new bucket name for the self-host version artifacts. 

This will also allow us to not have to make code changes if bucket names do change; we will just be able to change the secret. 

Let me know if there are any questions. Or any other places that will have to be updated along with this. Since the client's workflows use a secret in the key vault, once this is pushed through, I will update that secret with the new name. 
