### PR TITLE
[DEVOPS-1645] - FIX: beta tag for docker hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,7 @@ jobs:
           ./skopeo --version
           ./skopeo login $_AZ_REGISTRY -u 00000000-0000-0000-0000-000000000000 -p $(az acr login --expose-token --name ${_AZ_REGISTRY%.azurecr.io} | jq -r .accessToken)
           ./skopeo copy --all docker://$_AZ_REGISTRY/self-host:beta docker://docker.io/bitwarden/self-host:$_RELEASE_VERSION
+          ./skopeo copy --all docker://$_AZ_REGISTRY/self-host:beta docker://docker.io/bitwarden/self-host:beta # TODO: Delete after GA
           # ./skopeo copy --all docker://$_AZ_REGISTRY/self-host:beta docker://docker.io/bitwarden/self-host:latest # TODO: uncomment after GA
 
       - name: Log out of Docker, skopeo and disable Docker Notary


### PR DESCRIPTION
- This [card](https://bitwarden.atlassian.net/browse/DEVOPS-1645)
- Fixes the missing beta tag that's missing when we release