### PR TITLE
Unified: allow changing of nginx real_ip_header

### DIFF
--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -47,7 +47,7 @@ server {
 {{#each (String.Split env.BW_REAL_IPS ",")}}
   set_real_ip_from {{{String.Trim .}}};
 {{/each}}
-  real_ip_header X-Forwarded-For;
+  real_ip_header {{{String.Coalesce env.BW_REAL_IP_HEADER "X-Forwarded-For"}}};
   real_ip_recursive on;
 {{/if}}
 

--- a/docker-unified/settings.env
+++ b/docker-unified/settings.env
@@ -67,3 +67,5 @@ BW_INSTALLATION_KEY=xxxxxxxxxxxx
 #globalSettings__disableUserRegistration=false
 #globalSettings__hibpApiKey=REPLACE
 #adminSettings__admins=admin1@email.com,admin2@email.com
+#BW_REAL_IPS=127.0.0.1,172.16.0.0/12
+#BW_REAL_IP_HEADER=X-Forwarded-For


### PR DESCRIPTION
Some proxies don't use `X-Forwarded-For`, but set different headers. Synology's "Web Station" for example sets `X-Real-Ip` instead.

It's such a small change, I thought I'd ask if you accept pull requests by opening a pull request ;)