### PR TITLE
Added a warning message if running the Bitwarden Install script as root

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -19,6 +19,27 @@ https://bitwarden.com, https://github.com/bitwarden
 
 EOF
 
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+if [ "$EUID" -eq 0 ]; then
+    echo -e "${RED}WARNING: Running this script as root is not recommended!"
+    echo -e "${RED}Please refer to the installation guide for best practice: https://bitwarden.com/help/install-on-premise-linux/#install-bitwarden.${NC}"
+    read -p "Do you still want to continue? (y/n): " choice
+
+    # Check the user's choice
+    case "$choice" in
+        [Yy]|[Yy][Ee][Ss])
+            echo "Continuing...."
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+fi
+
+
+
 # Setup
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -25,16 +25,16 @@ NC='\033[0m' # No Color
 if [ "$EUID" -eq 0 ]; then
     echo -e "${RED}WARNING: This script is running as the root user!"
     echo -e "If you are running a standard deployment this script should be running as a dedicated Bitwarden User as per the documentation."
-    read -p "Do you still want to continue? (y/n): ${NC}" choice
+    read -p "Do you still want to continue? (y/n): " choice
 
     # Check the user's choice
     case "$choice" in
         [Yy]|[Yy][Ee][Ss])
-            echo "${NC}Continuing...."
+            echo -e "${NC}Continuing...."
             ;;
         *)
             exit 1
-            echo "${NC}"
+            echo -e "${NC}"
             ;;
     esac
 fi

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -33,8 +33,7 @@ if [ "$EUID" -eq 0 ]; then
             echo -e "Continuing...."
             ;;
         *)
-            exit 1
-            
+            exit 1         
             ;;
     esac
 fi

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -24,16 +24,17 @@ NC='\033[0m' # No Color
 
 if [ "$EUID" -eq 0 ]; then
     echo -e "${RED}WARNING: This script is running as the root user!"
-    echo -e "${RED}If you are running a standard deployment this script should be running as the dedicated Bitwarden User."
-    read -p "Do you still want to continue? (y/n): " choice
+    echo -e "If you are running a standard deployment this script should be running as a dedicated Bitwarden User as per the documentation."
+    read -p "Do you still want to continue? (y/n): ${NC}" choice
 
     # Check the user's choice
     case "$choice" in
         [Yy]|[Yy][Ee][Ss])
-            echo "Continuing...."
+            echo "${NC}Continuing...."
             ;;
         *)
             exit 1
+            echo "${NC}"
             ;;
     esac
 fi

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -24,17 +24,17 @@ NC='\033[0m' # No Color
 
 if [ "$EUID" -eq 0 ]; then
     echo -e "${RED}WARNING: This script is running as the root user!"
-    echo -e "If you are running a standard deployment this script should be running as a dedicated Bitwarden User as per the documentation."
+    echo -e "If you are running a standard deployment this script should be running as a dedicated Bitwarden User as per the documentation.${NC}"
     read -p "Do you still want to continue? (y/n): " choice
 
     # Check the user's choice
     case "$choice" in
         [Yy]|[Yy][Ee][Ss])
-            echo -e "${NC}Continuing...."
+            echo -e "Continuing...."
             ;;
         *)
             exit 1
-            echo -e "${NC}"
+            
             ;;
     esac
 fi

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -23,8 +23,8 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 if [ "$EUID" -eq 0 ]; then
-    echo -e "${RED}WARNING: Running this script as root is not recommended!"
-    echo -e "${RED}Please refer to the installation guide for best practice: https://bitwarden.com/help/install-on-premise-linux/#install-bitwarden.${NC}"
+    echo -e "${RED}WARNING: This script is running as the root user!"
+    echo -e "${RED}If you are running a standard deployment this script should be running as the dedicated Bitwarden User."
     read -p "Do you still want to continue? (y/n): " choice
 
     # Check the user's choice


### PR DESCRIPTION
Running the install script as root causes known issues in the product. The person running the script may not realise that a dedicated user is advised in the documentation or have missed the step to create the Bitwarden user. This will also catch users who are running an update of the product as the root user, which can also cause issues. 

It is worth noting that this may result in an increase of service desk tickets for users upgrading who have historically done so as root and are now concerned.

