### PR TITLE
Add compressLogs Functionality to Bitwarden Self-Hosted (Bash)

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -259,7 +259,7 @@ case $1 in
         $SCRIPTS_DIR/run.sh uninstall $OUTPUT
         ;;
     "compresslogs")
-        # checkOutputDirExists        
+        checkOutputDirExists        
         compressLogs $OUTPUT $2 $3
         ;;
     "help")

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -130,10 +130,10 @@ function compressLogs() {
     tempfile=$(mktemp)
 
     function validateDateFormat() {
-    if ! [[ $1 =~ ^[0-9]{8}$ ]]; then
-        echo "Error: $2 date format is invalid. Please use YYYYMMDD."
-        exit 1
-    fi
+        if ! [[ $1 =~ ^[0-9]{8}$ ]]; then
+            echo "Error: $2 date format is invalid. Please use YYYYMMDD."
+            exit 1
+        fi
     }
 
     function validateDateOrder() {


### PR DESCRIPTION
## Description

Introduces a new feature to the Bitwarden self-hosted script `bitwarden.sh` – the ability to compress and archive logs within a specified date range, or all logs if no range is provided. 

This enhancement simplifies log management, particularly for troubleshooting and audit purposes, by allowing administrators to easily package relevant log files.

## Features

- [x] Compress logs between two dates (`START_DATE` and `END_DATE`) specified in `YYYYMMDD` format.
- [x] Optionally compress all logs if no date range is provided.
- [x] Validates date format and ensures `START_DATE` is not after `END_DATE`.
- [x] Creates the compressed archive in the current directory, naming it based on the date range or as "all" for complete log compression.

## Usage examples

Compress logs from March 4th, 2024 to March 5th, 2024:
```bash
./bitwarden.sh compresslogs 20240304 20240305
```

A compressed file `bitwarden-logs-20240304-to-20240305.tar.gz` is produced.

Compress all logs:
```bash
./bitwarden.sh compresslogs
```

A compress file `bitwarden-logs-all.tar.gz` is produced

## Testing

Please review this PR for inclusion in the next release of Bitwarden self-hosted. Your feedback and suggestions are welcome!