### PR TITLE
Add ShareConfig Functionality for Secure Configuration Sharing to Bitwarden Self-Hosted (Bash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 # Secrets file for act (gh actions local run tool)
 .secrets
-bwdata
-bwdata.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Secrets file for act (gh actions local run tool)
 .secrets
+bwdata
+bwdata.zip

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -139,6 +139,7 @@ updateconf
 uninstall
 renewcert
 rebuild
+shareconfig
 help
 
 See more at https://bitwarden.com/help/article/install-on-premise/#script-commands-reference
@@ -194,6 +195,9 @@ case $1 in
     "uninstall")
         checkOutputDirExists
         $SCRIPTS_DIR/run.sh uninstall $OUTPUT
+        ;;
+    "shareconfig")
+        checkOutputDirExists
         ;;
     "help")
         listCommands

--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -148,7 +148,9 @@ function shareConfig() {
     tar -czf "$OUTPUT_FILE" -C "$TEMP_DIR" .
     rm -rf "$TEMP_DIR"
 
-    echo "The redacted configuration files have been successfully compressed and saved as '$OUTPUT_FILE'."
+    echo "The redacted configuration files have been compressed and saved as '$OUTPUT_FILE'."
+    echo "We have attempted to automatically mask sensitive values from your configuration files, however please ensure you check this before sharing."
+    echo "You may wish to remove these configuration files from the provided."
 }
 
 


### PR DESCRIPTION
## Description

Introduces the `shareconfig` functionality to the Bitwarden self-hosted setup script, enabling administrators to securely share their Bitwarden configuration files. The `shareconfig`  command sanitizes sensitive information by redacting values associated with passwords and secrets before compressing the configuration files into a `tar.gz` archive. This ensures that critical information remains secure when configuration files need to be shared for troubleshooting or auditing purposes.

## Features

- [x] Redacts sensitive information, including passwords and secret keys, in `.conf`, `.env`, `.xml`, and `.yml` files within the Bitwarden configuration directory.
- [x] Maintains the original directory structure in the compressed archive.
- [x] Generates a `tar.gz` archive of the sanitized configuration files, ready for secure sharing with support teams or for audit purposes.

## Usage examples

To use this functionality, run the following command from the Bitwarden self-hosted script directory:

```bash
./bitwarden.sh shareconfig
```

This will generate a file named `bitwarden-configs-redacted-<timestamp>.tar.gz` in the current directory.

## Testing

Please review this PR for inclusion in the next release of Bitwarden self-hosted. Your feedback and suggestions are welcome!

