### PR TITLE
CLOUDOPS-1486 Remove R2 secrets and step from selfhost

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,7 @@ jobs:
           keyvault: "bitwarden-ci"
           secrets: "aws-selfhost-version-access-id,
             aws-selfhost-version-access-key,
-            aws-selfhost-version-bucket-name,
-            r2-electron-access-id,
-            r2-electron-access-key,
-            r2-bitwarden-selfhost-version-bucket-name,
-            cf-prod-account"
+            aws-selfhost-version-bucket-name"
 
       - name: Upload version.json to S3 bucket
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
@@ -133,19 +129,6 @@ jobs:
           aws s3 cp version.json $AWS_S3_BUCKET_NAME \
           --acl "public-read" \
           --quiet
-
-      - name: Upload version.json to R2 bucket
-        if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.r2-electron-access-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.r2-electron-access-key }}
-          AWS_DEFAULT_REGION: 'us-east-1'
-          AWS_S3_BUCKET_NAME: ${{ steps.retrieve-secrets.outputs.r2-bitwarden-selfhost-version-bucket-name }}
-          CF_ACCOUNT: ${{ steps.retrieve-secrets.outputs.cf-prod-account }}
-        run: |
-          aws s3 cp version.json $AWS_S3_BUCKET_NAME \
-          --quiet \
-          --endpoint-url https://${CF_ACCOUNT}.r2.cloudflarestorage.com
 
   tag-docker-latest:
     name: Tag Docker Hub images with release version and latest


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
- Remove R2 bucket secrets and publish artifacts to R2 step from selfhost release workflow

- This is required as part of the migration from Cloudflare to Fastly for this static asset

- We will use the existing AWS S3 buckets as the origins fronted by Fastly

## Code changes
- **release.yml** Removed R2, CF secrets from **Retrieve secrets** step and removed **Publish artifacts to R2** step