### PR TITLE
Remove version in docker-compose

### DIFF
--- a/docker-unified/docker-compose.yml
+++ b/docker-unified/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 
 services:
   bitwarden:


### PR DESCRIPTION
Version is completely optional for docker compose and in the newest version is being labeled as obsolete. 

[04-version-and-name.md](https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md)
