### PR TITLE
BRE-99 - Remove old docker-compose syntax

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -50,12 +50,6 @@ if [ $# -eq 2 ]
 then
     OUTPUT=$2
 fi
-if command -v docker-compose &> /dev/null
-then
-    dccmd='docker-compose'
-else
-    dccmd='docker compose'
-fi
 
 SCRIPTS_DIR="$OUTPUT/scripts"
 BITWARDEN_SCRIPT_URL="https://func.bitwarden.com/api/dl/?app=self-host&platform=linux"
@@ -68,12 +62,7 @@ KEYCONNECTORVERSION="2024.4.0"
 
 echo "bitwarden.sh version $COREVERSION"
 docker --version
-if [[ "$dccmd" == "docker compose" ]]; then
-    $dccmd version
-else
-    $dccmd --version
-fi
-
+docker compose version
 echo ""
 
 # Functions

--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Setup
-if command -v docker-compose &> /dev/null
-then
-    dccmd='docker-compose'
-else
-    dccmd='docker compose'
-fi
-
 CYAN='\033[0;36m'
 RED='\033[1;31m'
 NC='\033[0m' # No Color
@@ -108,19 +100,19 @@ function install() {
 function dockerComposeUp() {
     dockerComposeFiles
     dockerComposeVolumes
-    $dccmd up -d
+    docker compose up -d
 }
 
 function dockerComposeDown() {
     dockerComposeFiles
-    if [ $($dccmd ps | wc -l) -gt 2 ]; then
-        $dccmd down
+    if [ $(docker compose ps | wc -l) -gt 2 ]; then
+        docker compose down
     fi
 }
 
 function dockerComposePull() {
     dockerComposeFiles
-    $dccmd pull
+    docker compose pull
 }
 
 function dockerComposeFiles() {
@@ -187,7 +179,7 @@ function forceUpdateLetsEncrypt() {
 function updateDatabase() {
     pullSetup
     dockerComposeFiles
-    MSSQL_ID=$($dccmd ps -q mssql)
+    MSSQL_ID=$(docker compose ps -q mssql)
     docker run -i --rm --name setup --network container:$MSSQL_ID \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
@@ -196,11 +188,11 @@ function updateDatabase() {
 
 function updatebw() {
     KEY_CONNECTOR_ENABLED=$(grep 'enable_key_connector:' $OUTPUT_DIR/config.yml | awk '{ print $2}')
-    CORE_ID=$($dccmd ps -q admin)
-    WEB_ID=$($dccmd ps -q web)
+    CORE_ID=$(docker compose ps -q admin)
+    WEB_ID=$(docker compose ps -q web)
     if [ "$KEY_CONNECTOR_ENABLED" = true ];
     then
-        KEYCONNECTOR_ID=$($dccmd ps -q key-connector)
+        KEYCONNECTOR_ID=$(docker compose ps -q key-connector)
     fi
 
     if [ $KEYCONNECTOR_ID ] &&


### PR DESCRIPTION
This PR removes the old `docker-compose` syntax from our Linux scripts.  Any users that encounter an error will need to update their Docker engine to a newer version.