### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug Report
+description: Submit a bug report to help us improve
+title: 'bug report: '
+labels:
+  - kind/bug/report
+  - meta/needs triage
+
+body:
+  - type: checkboxes
+    id: preliminary-checks
+    attributes:
+      label: Preliminary Checks
+      description: |
+        By submitting this issue, you agree to our code of conduct.
+      options:
+        - label: I tried searching for an existing issue and followed the [debugging docs](https://docker-mailserver.github.io/docker-mailserver/latest/config/debugging/) advice, but still need assistance.
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: 👀 What Happened?
+      description: How did this differ from your expectations?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Reproduction Steps
+      description: |
+        How did you trigger this bug? Please walk us through it step by step.
+        Please use [fenced code blocks](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) when pasting lots of text!
+      placeholder: The easier it is for us to reproduce your issue, the sooner we can help resolve it 😉
+
+  - type: input
+    id: bitwarden-version
+    attributes:
+      label: Bitwarden Version
+      description: On which version (image tag) did you encounter this bug?
+      placeholder: 2024.8.1-beta (do not put "latest")
+    validations:
+      required: true
+
+  - type: input
+    id: system
+    attributes:
+      label: System Information
+      description: |
+        Which OS are you hosting Bitwarden on? Which container orchestration tool are you using?
+      placeholder: Debian 11 (Bullseye) x86_64, Fedora 38 ARM64, Docker
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant-log-output
+    attributes:
+      label: Relevant log output
+      description: |
+        Show us relevant log output here.
+        - This field expects only plain text (_rendered as a fenced code block_).
+        - You can enable debug output by setting the environment variable `LOG_LEVEL` to `debug` or `trace`.
+      render: Text
+
+  - type: input
+    id: form-improvements
+    attributes:
+      label: Improvements to this form?
+      description: If you have criticism or general feedback about this issue form, feel free to tell us so we can enhance the experience for everyone.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Website | Help Center
+    url: https://bitwarden.com/help/
+    about: Visit this first before opening issues!
+  - name: Documentation | Contributing
+    url: https://contributing.bitwarden.com/
+    about: How to contribute to Bitwarden

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: 'feature request: '
+labels:
+  - kind/new feature
+  - meta/needs triage
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Markdown formatting can be used in almost all text fields. The description will tell you if this is not the case for a specific field.
+
+        Be as precise as possible, and if in doubt, it's best to add more information that too few.
+
+        ---
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Tell us how your request is related to DMS, one of its components or another issue / PR. Also **link all conected issues and PRs here**!
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the solution you would like to have implemented. Be as precise as possible!
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Which alternatives have you considered?
+    validations:
+      required: true
+
+  - type: textarea
+    id: applicable-users
+    attributes:
+      label: Applicable Users
+      description: Who will that feature be useful to?
+    validations:
+      required: true
+
+  - type: textarea
+    id: contribution
+    attributes:
+      label: What are you going to contribute?
+      description: You may also tell us what you have already done.
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds issue templates. See an already running version [here](https://github.com/georglauterbach/bitwarden-self-host/issues/new/choose). When this PR is merged, the "New Issue" functionality will look identical.

@vgrassia not sure who to ask for a review here; just mentioning you here because you are the last human commiter to this repository.