### PR TITLE
[PM-8825] Fix: `run.sh` script is deleted if bad response code is received

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -93,16 +93,20 @@ function downloadRunFile() {
     then
         mkdir $SCRIPTS_DIR
     fi
-    run_file_status_code=$(curl -s -L -w "%{http_code}" -o $SCRIPTS_DIR/run.sh $RUN_SCRIPT_URL)
+
+    local tmp_script=$(mktemp)
+
+    run_file_status_code=$(curl -s -L -w "%{http_code}" -o $tmp_script $RUN_SCRIPT_URL)
     if echo "$run_file_status_code" | grep -q "^20[0-9]"
     then
+        mv $tmp_script $SCRIPTS_DIR/run.sh
         chmod u+x $SCRIPTS_DIR/run.sh
         rm -f $SCRIPTS_DIR/install.sh
     else
         echo "Unable to download run script from $RUN_SCRIPT_URL. Received status code: $run_file_status_code"
         echo "http response:"
-        cat $SCRIPTS_DIR/run.sh
-        rm -f $SCRIPTS_DIR/run.sh
+        cat $tmp_script
+        rm -f $tmp_script
         exit 1
     fi
 }


### PR DESCRIPTION
This fixes #262 by only overwriting an existing `run.sh` script if we receive a success response. 