### PR TITLE
[PM-368] Setup container attaches itself to docker_internal network during database update

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -172,7 +172,7 @@ function Update-Database {
 
     # only use container network driver if using the included mssql image
     $dockerNetworkArgs = ""
-    if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1') {
+    if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1433') {
         $dockerNetworkArgs = "--network container:$mssqlId"
     }
 

--- a/run.ps1
+++ b/run.ps1
@@ -168,11 +168,11 @@ function Force-Update-Lets-Encrypt {
 function Update-Database {
     Pull-Setup
     Docker-Compose-Files
-    $mssqlId = docker-compose ps -q mssql
 
     # only use container network driver if using the included mssql image
     $dockerNetworkArgs = ""
     if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1433') {
+        $mssqlId = docker-compose ps -q mssql
         $dockerNetworkArgs = "--network container:$mssqlId"
     }
 

--- a/run.ps1
+++ b/run.ps1
@@ -1,5 +1,5 @@
 param (
-    [string]$outputDir = "../.",
+    [string]$outputDir = "..\.",
     [string]$coreVersion = "latest",
     [string]$webVersion = "latest",
     [string]$keyConnectorVersion = "latest",
@@ -18,6 +18,7 @@ param (
 # Setup
 
 $dockerDir = "${outputDir}\docker"
+$envDir = "${outputDir}\env"
 $setupQuiet = 0
 $qFlag = ""
 $quietPullFlag = ""
@@ -42,22 +43,22 @@ function Install() {
     Write-Host "(!) " -f cyan -nonewline
     [string]$domain = $( Read-Host "Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com)" )
     echo ""
-    
+
     if ($domain -eq "") {
         $domain = "localhost"
     }
-    
+
     if ($domain -ne "localhost") {
         Write-Host "(!) " -f cyan -nonewline
         $letsEncrypt = $( Read-Host "Do you want to use Let's Encrypt to generate a free SSL certificate? (y/n)" )
         echo ""
-    
+
         if ($letsEncrypt -eq "y") {
             Write-Host "(!) " -f cyan -nonewline
             [string]$email = $( Read-Host ("Enter your email address (Let's Encrypt will send you certificate " +
                     "expiration reminders)") )
             echo ""
-    
+
             $letsEncryptPath = "${outputDir}/letsencrypt"
             if (!(Test-Path -Path $letsEncryptPath )) {
                 New-Item -ItemType directory -Path $letsEncryptPath | Out-Null
@@ -78,7 +79,7 @@ function Install() {
     if ($database -eq "") {
         $database = "vault"
     }
-    
+
     Pull-Setup
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
         dotnet Setup.dll -install 1 -domain ${domain} -letsencrypt ${letsEncrypt} `
@@ -168,7 +169,14 @@ function Update-Database {
     Pull-Setup
     Docker-Compose-Files
     $mssqlId = docker-compose ps -q mssql
-    docker run -it --rm --name setup --network container:$mssqlId `
+
+    # only use container network driver if using the included mssql image
+    $dockerNetworkArgs = ""
+    if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1') {
+        $dockerNetworkArgs = "--network container:$mssqlId"
+    }
+
+    docker run -it --rm --name setup $dockerNetworkArgs `
         -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
         dotnet Setup.dll -update 1 -db 1 -os win -corev $coreVersion -webv $webVersion `
         -keyconnectorv $keyConnectorVersion -q $setupQuiet
@@ -196,7 +204,7 @@ function Uninstall() {
         $uninstallAction = $( Read-Host "Are you sure you want to uninstall Bitwarden? (y/n)" )
     }
 
-    
+
     if ($uninstallAction -eq "y") {
         Write-Host "uninstalling Bitwarden..."
         Docker-Compose-Down
@@ -210,7 +218,7 @@ function Uninstall() {
 
     Write-Host "(!) " -f red -nonewline
         $purgeAction = $( Read-Host "Would you like to purge all local Bitwarden container images? (y/n)" )
-    
+
         if ($purgeAction -eq "y") {
             Docker-Prune
         }

--- a/run.sh
+++ b/run.sh
@@ -187,11 +187,11 @@ function forceUpdateLetsEncrypt() {
 function updateDatabase() {
     pullSetup
     dockerComposeFiles
-    MSSQL_ID=$($dccmd ps -q mssql)
 
     # only use container network driver if using the included mssql image
     if grep -q 'Data Source=tcp:mssql,1433' "$ENV_DIR/global.override.env"
     then
+        MSSQL_ID=$($dccmd ps -q mssql)
         local docker_network_args="--network container:$MSSQL_ID"
     fi
 

--- a/run.sh
+++ b/run.sh
@@ -63,24 +63,24 @@ function install() {
     echo -e -n "${CYAN}(!)${NC} Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com): "
     read DOMAIN
     echo ""
-    
+
     if [ "$DOMAIN" == "" ]
     then
         DOMAIN="localhost"
     fi
-    
+
     if [ "$DOMAIN" != "localhost" ]
     then
         echo -e -n "${CYAN}(!)${NC} Do you want to use Let's Encrypt to generate a free SSL certificate? (y/n): "
         read LETS_ENCRYPT
         echo ""
-    
+
         if [ "$LETS_ENCRYPT" == "y" ]
         then
             echo -e -n "${CYAN}(!)${NC} Enter your email address (Let's Encrypt will send you certificate expiration reminders): "
             read EMAIL
             echo ""
-    
+
             mkdir -p $OUTPUT_DIR/letsencrypt
             docker pull certbot/certbot
             docker run -it --rm --name certbot -p 80:80 -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
@@ -97,7 +97,7 @@ function install() {
     then
         DATABASE="vault"
     fi
-    
+
     pullSetup
     docker run -it --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
@@ -188,7 +188,14 @@ function updateDatabase() {
     pullSetup
     dockerComposeFiles
     MSSQL_ID=$($dccmd ps -q mssql)
-    docker run -i --rm --name setup --network container:$MSSQL_ID \
+
+    # only use container network driver if using the included mssql image
+    if grep -q 'Data Source=tcp:mssql,1433;' "$ENV_DIR/global.override.env"
+    then
+        local docker_network_args="--network container:$MSSQL_ID"
+    fi
+
+    docker run -i --rm --name setup $docker_network_args \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
     echo "Database update complete"
@@ -250,7 +257,6 @@ function uninstall() {
         read UNINSTALL_ACTION
     fi
 
-    
     if [ "$UNINSTALL_ACTION" == "y" ]
     then
         echo "Uninstalling Bitwarden..."
@@ -272,7 +278,6 @@ function uninstall() {
         dockerPrune
         echo -e -n "${CYAN}Bitwarden uninstall complete! ${NC}"
     fi
-    
 }
 
 function printEnvironment() {

--- a/run.sh
+++ b/run.sh
@@ -190,7 +190,7 @@ function updateDatabase() {
     MSSQL_ID=$($dccmd ps -q mssql)
 
     # only use container network driver if using the included mssql image
-    if grep -q 'Data Source=tcp:mssql,1433;' "$ENV_DIR/global.override.env"
+    if grep -q 'Data Source=tcp:mssql,1433' "$ENV_DIR/global.override.env"
     then
         local docker_network_args="--network container:$MSSQL_ID"
     fi


### PR DESCRIPTION
This fixes an issue where the run script was attaching itself to an isolated container network, even when using an external database, causing database updates to fail.

To fix this, we simply omit the `--network container:$MSSQL_ID` arg to docker when running the DB update when using an external database.