### PR TITLE
Breaking change: remove support for deprecated `docker-compose` CLI

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -2,9 +2,9 @@
 set -e
 
 cat << "EOF"
- _     _ _                         _            
-| |__ (_) |___      ____ _ _ __ __| | ___ _ __  
-| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \ 
+ _     _ _                         _
+| |__ (_) |___      ____ _ _ __ __| | ___ _ __
+| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
 | |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
 |_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|
 
@@ -33,7 +33,7 @@ if [ "$EUID" -eq 0 ]; then
             echo -e "Continuing...."
             ;;
         *)
-            exit 1         
+            exit 1
             ;;
     esac
 fi
@@ -68,11 +68,7 @@ KEYCONNECTORVERSION="2024.8.0"
 
 echo "bitwarden.sh version $COREVERSION"
 docker --version
-if [[ "$dccmd" == "docker compose" ]]; then
-    $dccmd version
-else
-    $dccmd --version
-fi
+docker compose version
 
 echo ""
 
@@ -151,7 +147,7 @@ function compressLogs() {
             exit 1
         fi
     fi
-    
+
     # Validate end date format and order
     if [ -n "$END_DATE" ]; then
         validateDateFormat "$END_DATE" "end"
@@ -257,7 +253,7 @@ case $1 in
         $SCRIPTS_DIR/run.sh uninstall $OUTPUT
         ;;
     "compresslogs")
-        checkOutputDirExists        
+        checkOutputDirExists
         compressLogs $OUTPUT $2 $3
         ;;
     "help")

--- a/run.ps1
+++ b/run.ps1
@@ -172,7 +172,7 @@ function Update-Database {
 
     # only use container network driver if using the included mssql image
     $dockerNetworkArgs = ""
-    if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1') {
+    if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1433') {
         $dockerNetworkArgs = "--network container:$mssqlId"
     }
 

--- a/run.ps1
+++ b/run.ps1
@@ -168,11 +168,11 @@ function Force-Update-Lets-Encrypt {
 function Update-Database {
     Pull-Setup
     Docker-Compose-Files
-    $mssqlId = docker-compose ps -q mssql
 
     # only use container network driver if using the included mssql image
     $dockerNetworkArgs = ""
     if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1433') {
+        $mssqlId = docker-compose ps -q mssql
         $dockerNetworkArgs = "--network container:$mssqlId"
     }
 

--- a/run.ps1
+++ b/run.ps1
@@ -1,5 +1,5 @@
 param (
-    [string]$outputDir = "../.",
+    [string]$outputDir = "..\.",
     [string]$coreVersion = "latest",
     [string]$webVersion = "latest",
     [string]$keyConnectorVersion = "latest",
@@ -18,6 +18,7 @@ param (
 # Setup
 
 $dockerDir = "${outputDir}\docker"
+$envDir = "${outputDir}\env"
 $setupQuiet = 0
 $qFlag = ""
 $quietPullFlag = ""
@@ -42,22 +43,22 @@ function Install() {
     Write-Host "(!) " -f cyan -nonewline
     [string]$domain = $( Read-Host "Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com)" )
     echo ""
-    
+
     if ($domain -eq "") {
         $domain = "localhost"
     }
-    
+
     if ($domain -ne "localhost") {
         Write-Host "(!) " -f cyan -nonewline
         $letsEncrypt = $( Read-Host "Do you want to use Let's Encrypt to generate a free SSL certificate? (y/n)" )
         echo ""
-    
+
         if ($letsEncrypt -eq "y") {
             Write-Host "(!) " -f cyan -nonewline
             [string]$email = $( Read-Host ("Enter your email address (Let's Encrypt will send you certificate " +
                     "expiration reminders)") )
             echo ""
-    
+
             $letsEncryptPath = "${outputDir}/letsencrypt"
             if (!(Test-Path -Path $letsEncryptPath )) {
                 New-Item -ItemType directory -Path $letsEncryptPath | Out-Null
@@ -78,7 +79,7 @@ function Install() {
     if ($database -eq "") {
         $database = "vault"
     }
-    
+
     Pull-Setup
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
         dotnet Setup.dll -install 1 -domain ${domain} -letsencrypt ${letsEncrypt} `
@@ -168,7 +169,14 @@ function Update-Database {
     Pull-Setup
     Docker-Compose-Files
     $mssqlId = docker-compose ps -q mssql
-    docker run -it --rm --name setup --network container:$mssqlId `
+
+    # only use container network driver if using the included mssql image
+    $dockerNetworkArgs = ""
+    if (Select-String -Path ${envDir}\global.override.env -Pattern 'Data Source=tcp:mssql,1') {
+        $dockerNetworkArgs = "--network container:$mssqlId"
+    }
+
+    docker run -it --rm --name setup $dockerNetworkArgs `
         -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
         dotnet Setup.dll -update 1 -db 1 -os win -corev $coreVersion -webv $webVersion `
         -keyconnectorv $keyConnectorVersion -q $setupQuiet
@@ -196,7 +204,7 @@ function Uninstall() {
         $uninstallAction = $( Read-Host "Are you sure you want to uninstall Bitwarden? (y/n)" )
     }
 
-    
+
     if ($uninstallAction -eq "y") {
         Write-Host "uninstalling Bitwarden..."
         Docker-Compose-Down
@@ -210,7 +218,7 @@ function Uninstall() {
 
     Write-Host "(!) " -f red -nonewline
         $purgeAction = $( Read-Host "Would you like to purge all local Bitwarden container images? (y/n)" )
-    
+
         if ($purgeAction -eq "y") {
             Docker-Prune
         }

--- a/run.sh
+++ b/run.sh
@@ -2,12 +2,12 @@
 set -e
 
 # Setup
-if command -v docker-compose &> /dev/null
+if ! docker compose version &> /dev/null
 then
-    dccmd='docker-compose'
-else
-    dccmd='docker compose'
+    echo "Error: 'docker compose' is not installed. Please install Docker Compose."
+    exit 1
 fi
+
 
 CYAN='\033[0;36m'
 RED='\033[1;31m'
@@ -108,19 +108,19 @@ function install() {
 function dockerComposeUp() {
     dockerComposeFiles
     dockerComposeVolumes
-    $dccmd up -d
+    docker compose up -d
 }
 
 function dockerComposeDown() {
     dockerComposeFiles
-    if [ $($dccmd ps | wc -l) -gt 2 ]; then
-        $dccmd down
+    if [ $(docker compose ps | wc -l) -gt 2 ]; then
+        docker compose down
     fi
 }
 
 function dockerComposePull() {
     dockerComposeFiles
-    $dccmd pull
+    docker compose pull
 }
 
 function dockerComposeFiles() {
@@ -191,7 +191,7 @@ function updateDatabase() {
     # only use container network driver if using the included mssql image
     if grep -q 'Data Source=tcp:mssql,1433' "$ENV_DIR/global.override.env"
     then
-        MSSQL_ID=$($dccmd ps -q mssql)
+        MSSQL_ID=$(docker compose ps -q mssql)
         local docker_network_args="--network container:$MSSQL_ID"
     fi
 
@@ -203,11 +203,11 @@ function updateDatabase() {
 
 function updatebw() {
     KEY_CONNECTOR_ENABLED=$(grep 'enable_key_connector:' $OUTPUT_DIR/config.yml | awk '{ print $2}')
-    CORE_ID=$($dccmd ps -q admin)
-    WEB_ID=$($dccmd ps -q web)
+    CORE_ID=$(docker compose ps -q admin)
+    WEB_ID=$(docker compose ps -q web)
     if [ "$KEY_CONNECTOR_ENABLED" = true ];
     then
-        KEYCONNECTOR_ID=$($dccmd ps -q key-connector)
+        KEYCONNECTOR_ID=$(docker compose ps -q key-connector)
     fi
 
     if [ $KEYCONNECTOR_ID ] &&

--- a/run.sh
+++ b/run.sh
@@ -187,11 +187,11 @@ function forceUpdateLetsEncrypt() {
 function updateDatabase() {
     pullSetup
     dockerComposeFiles
-    MSSQL_ID=$($dccmd ps -q mssql)
 
     # only use container network driver if using the included mssql image
     if grep -q 'Data Source=tcp:mssql,1433' "$ENV_DIR/global.override.env"
     then
+        MSSQL_ID=$($dccmd ps -q mssql)
         local docker_network_args="--network container:$MSSQL_ID"
     fi
 

--- a/run.sh
+++ b/run.sh
@@ -63,24 +63,24 @@ function install() {
     echo -e -n "${CYAN}(!)${NC} Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com): "
     read DOMAIN
     echo ""
-    
+
     if [ "$DOMAIN" == "" ]
     then
         DOMAIN="localhost"
     fi
-    
+
     if [ "$DOMAIN" != "localhost" ]
     then
         echo -e -n "${CYAN}(!)${NC} Do you want to use Let's Encrypt to generate a free SSL certificate? (y/n): "
         read LETS_ENCRYPT
         echo ""
-    
+
         if [ "$LETS_ENCRYPT" == "y" ]
         then
             echo -e -n "${CYAN}(!)${NC} Enter your email address (Let's Encrypt will send you certificate expiration reminders): "
             read EMAIL
             echo ""
-    
+
             mkdir -p $OUTPUT_DIR/letsencrypt
             docker pull certbot/certbot
             docker run -it --rm --name certbot -p 80:80 -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
@@ -97,7 +97,7 @@ function install() {
     then
         DATABASE="vault"
     fi
-    
+
     pullSetup
     docker run -it --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
@@ -188,7 +188,14 @@ function updateDatabase() {
     pullSetup
     dockerComposeFiles
     MSSQL_ID=$($dccmd ps -q mssql)
-    docker run -i --rm --name setup --network container:$MSSQL_ID \
+
+    # only use container network driver if using the included mssql image
+    if grep -q 'Data Source=tcp:mssql,1433;' "$ENV_DIR/global.override.env"
+    then
+        local docker_network_args="--network container:$MSSQL_ID"
+    fi
+
+    docker run -i --rm --name setup $docker_network_args \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
     echo "Database update complete"
@@ -250,7 +257,6 @@ function uninstall() {
         read UNINSTALL_ACTION
     fi
 
-    
     if [ "$UNINSTALL_ACTION" == "y" ]
     then
         echo "Uninstalling Bitwarden..."
@@ -272,7 +278,6 @@ function uninstall() {
         dockerPrune
         echo -e -n "${CYAN}Bitwarden uninstall complete! ${NC}"
     fi
-    
 }
 
 function printEnvironment() {

--- a/run.sh
+++ b/run.sh
@@ -190,7 +190,7 @@ function updateDatabase() {
     MSSQL_ID=$($dccmd ps -q mssql)
 
     # only use container network driver if using the included mssql image
-    if grep -q 'Data Source=tcp:mssql,1433;' "$ENV_DIR/global.override.env"
+    if grep -q 'Data Source=tcp:mssql,1433' "$ENV_DIR/global.override.env"
     then
         local docker_network_args="--network container:$MSSQL_ID"
     fi


### PR DESCRIPTION
Resolves #222. Removes compatibility with the deprecated `docker-compose` Python CLI. Users will need to upgrade to a modern, [supported version of Docker](https://bitwarden.com/help/install-on-premise-linux/#system-specifications) to continue self-hosting Bitwarden with our standard deployment process.

Note that this is only applicable to the Linux script. `docker-compose` on Windows is **not** the same thing as the deprecated `docker-compose` CLI. 