### PR TITLE
Run cosign only for published branches

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -166,11 +166,11 @@ jobs:
             "GH_PAT=${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
 
       - name: Install Cosign
-        if: inputs.is_workflow_call == true && github.ref == 'refs/heads/main'
+        if: inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Sign image with Cosign
-        if: inputs.is_workflow_call == true && github.ref == 'refs/heads/main'
+        if: inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
         env:
           DIGEST: ${{ steps.build-docker.outputs.digest }}
           TAGS: ${{ steps.tag-list.outputs.tags }}

--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -166,11 +166,11 @@ jobs:
             "GH_PAT=${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
 
       - name: Install Cosign
-        if: inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Sign image with Cosign
-        if: inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
         env:
           DIGEST: ${{ steps.build-docker.outputs.digest }}
           TAGS: ${{ steps.tag-list.outputs.tags }}

--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -166,11 +166,11 @@ jobs:
             "GH_PAT=${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
 
       - name: Install Cosign
-        if: github.event_name != 'pull_request' && inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && github.event_name != 'workflow_call' && github.ref == 'refs/heads/main'
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Sign image with Cosign
-        if: github.event_name != 'pull_request' && inputs.is_workflow_call != true && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && github.event_name != 'workflow_call' && github.ref == 'refs/heads/main'
         env:
           DIGEST: ${{ steps.build-docker.outputs.digest }}
           TAGS: ${{ steps.tag-list.outputs.tags }}

--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -166,11 +166,11 @@ jobs:
             "GH_PAT=${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
 
       - name: Install Cosign
-        if: github.event_name == 'workflow_call' && github.ref == 'refs/heads/main'
+        if: env.is_publish_branch == 'true'
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Sign image with Cosign
-        if: github.event_name == 'workflow_call' && github.ref == 'refs/heads/main'
+        if: env.is_publish_branch == 'true'
         env:
           DIGEST: ${{ steps.build-docker.outputs.digest }}
           TAGS: ${{ steps.tag-list.outputs.tags }}

--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -166,11 +166,11 @@ jobs:
             "GH_PAT=${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
 
       - name: Install Cosign
-        if: github.event_name != 'pull_request' && github.event_name != 'workflow_call' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'workflow_call' && github.ref == 'refs/heads/main'
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Sign image with Cosign
-        if: github.event_name != 'pull_request' && github.event_name != 'workflow_call' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'workflow_call' && github.ref == 'refs/heads/main'
         env:
           DIGEST: ${{ steps.build-docker.outputs.digest }}
           TAGS: ${{ steps.tag-list.outputs.tags }}


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to https://github.com/bitwarden/self-host/pull/325.

## 📔 Objective

We want the Cosign work to occur only for published branches.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
