### PR TITLE
[BRE-648] Fixing released unified to use correct variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
         run: |
           cosign sign --yes ghcr.io/bitwarden/$_PROJECT_NAME:$_RELEASE_TAG
           cosign sign --yes ghcr.io/bitwarden/$_PROJECT_NAME:latest
-      
+
       - name: Verify the signed image with Cosign
         run: |
           cosign verify \
@@ -397,26 +397,26 @@ jobs:
 
       - name: Tag release version and latest image
         run: |
-          docker tag $_AZ_REGISTRY/self-host:$_RELEASE_TAG ghcr.io/bitwarden/self-host:$_RELEASE_TAG
-          docker tag $_AZ_REGISTRY/self-host:$_RELEASE_TAG ghcr.io/bitwarden/self-host:latest
+          docker tag $_AZ_REGISTRY/self-host:$_RELEASE_VERSION ghcr.io/bitwarden/self-host:$_RELEASE_VERSION
+          docker tag $_AZ_REGISTRY/self-host:$_RELEASE_VERSION ghcr.io/bitwarden/self-host:latest
 
       - name: Push release version and latest image
         if: ${{ inputs.release_type != 'Dry Run' }}
         run: |
-          docker push ghcr.io/bitwarden/self-host:$_RELEASE_TAG
+          docker push ghcr.io/bitwarden/self-host:$_RELEASE_VERSION
           docker push ghcr.io/bitwarden/self-host:latest
 
       - name: Sign image with Cosign
         run: |
-          cosign sign --yes ghcr.io/bitwarden/self-host:$_RELEASE_TAG
+          cosign sign --yes ghcr.io/bitwarden/self-host:$_RELEASE_VERSION
           cosign sign --yes ghcr.io/bitwarden/self-host:latest
-      
+
       - name: Verify the signed image with Cosign
         run: |
           cosign verify \
             --certificate-identity "${{ github.server_url }}/${{ github.workflow_ref }}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            ghcr.io/bitwarden/self-host:$_RELEASE_TAG
+            ghcr.io/bitwarden/self-host:$_RELEASE_VERSION
 
           cosign verify \
             --certificate-identity "${{ github.server_url }}/${{ github.workflow_ref }}" \


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-648](https://bitwarden.atlassian.net/browse/BRE-648)

## 📔 Objective

Fixing `_RELEASE_TAG` variable in release unified section to be `_RELEASE_VERSION`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-648]: https://bitwarden.atlassian.net/browse/BRE-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ