### PR TITLE
fix: Setup is now self-contained and single-file

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -82,7 +82,7 @@ function Install() {
 
     Pull-Setup
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden ghcr.io/bitwarden/setup:$coreVersion `
-        dotnet Setup.dll -install 1 -domain ${domain} -letsencrypt ${letsEncrypt} `
+        /app/Setup -install 1 -domain ${domain} -letsencrypt ${letsEncrypt} `
         -os win -corev $coreVersion -webv $webVersion -keyconnectorv $keyConnectorVersion -q $setupQuiet -dbname "$database"
 }
 
@@ -178,7 +178,7 @@ function Update-Database {
 
     docker run -it --rm --name setup $dockerNetworkArgs `
         -v ${outputDir}:/bitwarden ghcr.io/bitwarden/setup:$coreVersion `
-        dotnet Setup.dll -update 1 -db 1 -os win -corev $coreVersion -webv $webVersion `
+        /app/Setup -update 1 -db 1 -os win -corev $coreVersion -webv $webVersion `
         -keyconnectorv $keyConnectorVersion -q $setupQuiet
     Write-Line "Database update complete"
 }
@@ -188,7 +188,7 @@ function Update([switch] $withpull) {
         Pull-Setup
     }
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden ghcr.io/bitwarden/setup:$coreVersion `
-        dotnet Setup.dll -update 1 -os win -corev $coreVersion -webv $webVersion `
+        /app/Setup -update 1 -os win -corev $coreVersion -webv $webVersion `
         -keyconnectorv $keyConnectorVersion -q $setupQuiet
 }
 
@@ -227,7 +227,7 @@ function Uninstall() {
 function Print-Environment {
     Pull-Setup
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden ghcr.io/bitwarden/setup:$coreVersion `
-        dotnet Setup.dll -printenv 1 -os win -corev $coreVersion -webv $webVersion `
+        /app/Setup -printenv 1 -os win -corev $coreVersion -webv $webVersion `
         -keyconnectorv $keyConnectorVersion -q $setupQuiet
 }
 

--- a/run.sh
+++ b/run.sh
@@ -104,7 +104,7 @@ function install() {
     pullSetup
     docker run -it --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env ghcr.io/bitwarden/setup:$COREVERSION \
-        dotnet Setup.dll -install 1 -domain $DOMAIN -letsencrypt $LETS_ENCRYPT -os $OS \
+        /app/Setup -install 1 -domain $DOMAIN -letsencrypt $LETS_ENCRYPT -os $OS \
         -corev $COREVERSION -webv $WEBVERSION -dbname "$DATABASE" -keyconnectorv $KEYCONNECTORVERSION
 }
 
@@ -200,7 +200,7 @@ function updateDatabase() {
 
     docker run -i --rm --name setup $docker_network_args \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env ghcr.io/bitwarden/setup:$COREVERSION \
-        dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
+        /app/Setup -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
     echo "Database update complete"
 }
 
@@ -242,7 +242,7 @@ function update() {
     fi
     docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env ghcr.io/bitwarden/setup:$COREVERSION \
-        dotnet Setup.dll -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
+        /app/Setup -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
 }
 
 function uninstall() {
@@ -287,7 +287,7 @@ function printEnvironment() {
     pullSetup
     docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env ghcr.io/bitwarden/setup:$COREVERSION \
-        dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
+        /app/Setup -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
 }
 
 function restart() {


### PR DESCRIPTION
## 📔 Objective

Changes in https://github.com/bitwarden/server/pull/5701 mean that we need to invoke Setup as `/app/Setup` instead of `dotnet Setup.dll`. This updates our `run` scripts to match the changes. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
