### PR TITLE
[PM-23175] fix(install): add DNS check to fail gracefully if name resolution fails

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -92,6 +92,11 @@ function downloadSelf() {
 }
 
 function downloadRunFile() {
+    if ! getent hosts func.bitwarden.com > /dev/null 2>&1; then
+        echo -e "${RED}DNS resolution failed. Please check /etc/resolv.conf or network connectivity.${NC}"
+        exit 1
+    fi
+
     if [ ! -d "$SCRIPTS_DIR" ]
     then
         mkdir $SCRIPTS_DIR


### PR DESCRIPTION

## 📔 Objective

Ensure the Bitwarden installation script fails gracefully with a clear error when DNS resolution is unavailable. Previously, a missing nameserver or DNS misconfiguration caused the script to silently fail during the run.sh download, making it hard to troubleshoot.



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
