### PR TITLE
Listen on IPv4 and IPv6

### DIFF
--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -1,6 +1,6 @@
 server {
   listen {{{String.Coalesce env.BW_PORT_HTTP "8080"}}} default_server;
-  #listen [::]:{{{String.Coalesce env.BW_PORT_HTTP "8080"}}} default_server;
+  listen [::]:{{{String.Coalesce env.BW_PORT_HTTP "8080"}}} default_server;
   server_name {{{String.Coalesce env.BW_DOMAIN "localhost"}}};
 {{#if (String.Equal env.BW_ENABLE_SSL "true")}}
 


### PR DESCRIPTION
Uncomment the listen directive for IPv6.

## 🎟️ Tracking

Fixes #172.

## 📔 Objective

Have nginx listen on both IPv4 and IPv6. IPv6 listen directive is commented out for seemingly no reason.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
