### PR TITLE
[BRE-1063] Show Error if cURL fails

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -82,12 +82,14 @@ echo ""
 # Functions
 
 function downloadSelf() {
-    if curl -L -s -w "http_code %{http_code}" -o $SCRIPT_PATH.1 $BITWARDEN_SCRIPT_URL | grep -q "^http_code 20[0-9]"
+    if curl -L -s -S -w "http_code %{http_code}" -o $SCRIPT_PATH.1 $BITWARDEN_SCRIPT_URL | grep -q "^http_code 20[0-9]"
     then
         mv -f $SCRIPT_PATH.1 $SCRIPT_PATH
         chmod u+x $SCRIPT_PATH
     else
+        exit_code=$?
         rm -f $SCRIPT_PATH.1
+        exit $exit_code
     fi
 }
 
@@ -99,7 +101,7 @@ function downloadRunFile() {
 
     local tmp_script=$(mktemp)
 
-    run_file_status_code=$(curl -s -L -w "%{http_code}" -o $tmp_script $RUN_SCRIPT_URL)
+    run_file_status_code=$(curl -s -S -L -w "%{http_code}" -o $tmp_script $RUN_SCRIPT_URL)
     if echo "$run_file_status_code" | grep -q "^20[0-9]"
     then
         mv $tmp_script $SCRIPTS_DIR/run.sh


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1063](https://bitwarden.atlassian.net/browse/BRE-1063)
## 📔 Objective

The error will no longer be suppressed if cURL fails and will show the user error output to provide feedback as to what went wrong, such as an incorrectly configured DNS
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes