### PR TITLE
[BRE-1153]: Track `main` web client for Unified dev tags

### DIFF
--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -11,6 +11,10 @@ on:
         description: "Server branch name to deploy (examples: 'main', 'rc', 'feature/sm')"
         type: string
         default: main
+      web_branch:
+        description: "Web client branch name to deploy (examples: 'main', 'rc', 'feature/sm')"
+        type: string
+        default: main
       use_latest_core_version:
         description: "Use the latest core version from versions.json instead of branch"
         type: boolean
@@ -159,6 +163,26 @@ jobs:
           ref: ${{ steps.server-branch-name.outputs.server_ref }}
           path: "server"
 
+      - name: Download web client branch artifacts for dev builds
+        if: steps.tag.outputs.image_tag == 'dev'
+        uses: bitwarden/gh-actions/download-artifacts@main
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          workflow: build-web.yml
+          workflow_conclusion: success
+          branch: ${{ inputs.web_branch }}
+          repo: bitwarden/clients
+          artifacts: "web-*-selfhosted-DEV.zip"
+
+      - name: Set web artifact path for dev builds
+        if: steps.tag.outputs.image_tag == 'dev'
+        id: set-web-artifact-path
+        run: |
+          WEB_ARTIFACT=$(find . -name "web-*-selfhosted-DEV.zip" | head -1)
+          if [[ -n "${WEB_ARTIFACT}" ]]; then
+            echo "WEB_ARTIFACT_PATH=${WEB_ARTIFACT}" >> $GITHUB_ENV
+          fi
+
       - name: Build and push Docker image
         id: build-docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -171,6 +195,8 @@ jobs:
             linux/arm64/v8
           push: true
           tags: ${{ steps.tag-list.outputs.tags }}
+          build-args: |
+            WEB_ARTIFACT_PATH=${{ env.WEB_ARTIFACT_PATH }}
 
       - name: Install Cosign
         if: env.is_publish_branch == 'true'
@@ -215,7 +241,7 @@ jobs:
           ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
 
       - name: Log out of Docker
-        if: ${{ env.is_publish_branch == 'true' }}
+        if: env.is_publish_branch == 'true'
         run: |
           docker logout ghcr.io
           docker logout $_AZ_REGISTRY

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -3,6 +3,7 @@
 #                 Build stage                 #
 ###############################################
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS web-setup
+ARG WEB_ARTIFACT_PATH
 
 # Add packages
 RUN apk add --no-cache \
@@ -14,21 +15,32 @@ RUN apk add --no-cache \
 WORKDIR /tmp
 
 # Grab last tag/release of the 'web' client
-RUN git ls-remote --tags https://github.com/bitwarden/clients.git | grep refs/tags/web | cut -d/ -f3 | sort -Vr | head -1 > tag.txt
-
-RUN cat tag.txt
+RUN  if [ -z "${WEB_ARTIFACT_PATH}" ]; then \
+    git ls-remote --tags https://github.com/bitwarden/clients.git | grep refs/tags/web | cut -d/ -f3 | sort -Vr | head -1 > tag.txt; \
+    fi
 
 # Extract the version of the 'web' client
-RUN cat tag.txt | grep -o -E "[0-9]{4}\.[0-9]{1,2}\.[0-9]+" > version.txt
+RUN if [ -z "${WEB_ARTIFACT_PATH}" ]; then \
+    cat tag.txt | grep -o -E "[0-9]{4}\.[0-9]{1,2}\.[0-9]+" > version.txt; \
+    fi
 
 # Download the built release artifact for the 'web' client
-RUN TAG=$(cat tag.txt) \
-  && VERSION=$(cat version.txt) \
-  && curl --proto "=https" -L https://github.com/bitwarden/clients/releases/download/$TAG/web-$VERSION-selfhosted-COMMERCIAL.zip -O
+RUN if [ -z "${WEB_ARTIFACT_PATH}" ]; then \
+    TAG=$(cat tag.txt) \
+    && VERSION=$(cat version.txt) \
+    && curl --proto "=https" -L https://github.com/bitwarden/clients/releases/download/$TAG/web-$VERSION-selfhosted-COMMERCIAL.zip -O; \
+    fi
+
+# Copy provided web artifact if available
+COPY ${WEB_ARTIFACT_PATH}* /tmp/
 
 # Unzip the 'web' client to /tmp/build
-RUN VERSION=$(cat version.txt) \
-  && unzip web-$VERSION-selfhosted-COMMERCIAL.zip
+RUN if [ -z "${WEB_ARTIFACT_PATH}" ]; then \
+    VERSION=$(cat version.txt) \
+    && unzip web-$VERSION-selfhosted-COMMERCIAL.zip; \
+    else \
+    unzip ${WEB_ARTIFACT_PATH} -d /tmp/; \
+    fi
 
 ###############################################
 #                 Build stage                 #
@@ -41,11 +53,11 @@ ARG TARGETPLATFORM
 # Determine proper runtime value for .NET
 # We put the value in a file to be read by later layers.
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-      RID=linux-musl-x64 ; \
+    RID=linux-musl-x64 ; \
     elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-      RID=linux-musl-arm64 ; \
+    RID=linux-musl-arm64 ; \
     elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
-      RID=linux-musl-arm ; \
+    RID=linux-musl-arm ; \
     fi \
     && echo "RID=$RID" > /tmp/rid.txt
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/BRE-1153
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Sets Unified to track the Web client from `main` branch when the Unified container is built from `main` branch of the server, aka `dev` tag.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Uses the newest artifact here: https://github.com/bitwarden/clients/pull/16475
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
