### PR TITLE
[PM-26937] INT-252 Remove checksmtp command from bitwarden.sh

### DIFF
--- a/bitwarden.sh
+++ b/bitwarden.sh
@@ -192,57 +192,6 @@ function compressLogs() {
     rm $tempfile
 }
 
-function checkSmtp() {
-    CONFIG_FILE="$1/env/global.override.env"
-
-    if [ ! -f "$CONFIG_FILE" ]; then
-        echo "Configuration file not found at $CONFIG_FILE"
-        exit 1
-    fi
-
-    if ! command -v openssl &> /dev/null; then
-        echo "OpenSSL is not available but is required for this check."
-        exit 1
-    fi
-
-    host=$(grep 'globalSettings__mail__smtp__host=' "$CONFIG_FILE" | cut -d '=' -f2)
-    port=$(grep 'globalSettings__mail__smtp__port=' "$CONFIG_FILE" | cut -d '=' -f2)
-    ssl=$(grep 'globalSettings__mail__smtp__ssl=' "$CONFIG_FILE" | cut -d '=' -f2)
-    username=$(grep 'globalSettings__mail__smtp__username=' "$CONFIG_FILE" | cut -d '=' -f2)
-    password=$(grep 'globalSettings__mail__smtp__password=' "$CONFIG_FILE" | cut -d '=' -f2)
-
-    if [ "$ssl" == "true" ]; then
-        ssl_command="-ssl"
-    else
-        ssl_command="-starttls smtp"
-    fi
-
-    set +e
-    SMTP_RESPONSE=$(
-        {
-            echo "EHLO localhost"
-            if [ "$ssl_command" != "-ssl" ]; then
-                echo "STARTTLS"
-                sleep 2
-                echo "EHLO localhost"
-            fi
-            # Check if username and password are set before proceeding
-            if [[ -n "$username" && -n "$password" ]]; then
-                echo "AUTH LOGIN"
-                echo "$(echo -ne "$username" | base64)"
-                echo "$(echo -ne "$password" | base64)"
-            fi
-            echo "QUIT"
-        } | openssl s_client -connect $host:$port $ssl_command -ign_eof 2>/dev/null
-    )
-
-    if echo "$SMTP_RESPONSE" | grep -q "^2[0-9][0-9] "; then
-        echo -e "SMTP settings are correct."
-    else
-        echo "SMTP authentication failed or connection error occurred."
-    fi
-}
-
 function listCommands() {
 cat << EOT
 Available commands:
@@ -319,10 +268,6 @@ case $1 in
     "compresslogs")
         checkOutputDirExists
         compressLogs $OUTPUT $2 $3
-        ;;
-    "checksmtp")
-        checkOutputDirExists
-        checkSmtp $OUTPUT
         ;;
     "help")
         listCommands


### PR DESCRIPTION
## 🎟️ Tracking

[<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->]()

- [https://bitwarden.atlassian.net/browse/INT-252](https://bitwarden.atlassian.net/browse/INT-252)

## 📔 Objective

Remove checksmtp command from bitwarden.sh as it doesn’t work reliably.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
