### PR TITLE
BRE-1355 - Allow Bitwarden lite to be built before release

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -23,6 +23,24 @@ on:
         description: "Use the latest web version from version.json instead of branch"
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      server_branch:
+        description: "Server branch name (examples: 'main', 'rc', 'feature/sm')"
+        type: string
+        default: main
+      web_branch:
+        description: "Web client branch name (examples: 'main', 'rc', 'feature/sm')"
+        type: string
+        default: main
+      use_latest_core_version:
+        description: "Use the latest core version from version.json instead of branch"
+        type: boolean
+        default: false
+      use_latest_web_version:
+        description: "Use the latest web version from version.json instead of branch"
+        type: boolean
+        default: false
   pull_request:
     paths:
       - ".github/workflows/build-bitwarden-lite.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,11 +403,27 @@ jobs:
         uses: bitwarden/gh-actions/azure-logout@main
 
 
+  build-lite-image:
+    name: Build Bitwarden lite image
+    uses: ./.github/workflows/build-bitwarden-lite.yml
+    needs: update-versions
+    permissions:
+      id-token: write
+      packages: write
+      security-events: write
+    with:
+      use_latest_core_version: true
+      use_latest_web_version: true
+    secrets: inherit
+
+
   release-bitwarden-lite:
     name: Release Bitwarden lite
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: update-versions
+    needs:
+      - update-versions
+      - build-lite-image
     env:
       _CORE_VERSION: ${{ needs.update-versions.outputs.core_release_tag }}
     permissions:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-1355](https://bitwarden.atlassian.net/browse/BRE-1355?atlOrigin=eyJpIjoiYzUzZmQyYjFhZDBhNGE0NTg1NjczYTc2YWVmODc0Y2QiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR modifies the Build Bitwarden lite workflow to be callable and the Release workflow to build Bitwarden lite with the latest Core and Web versions before releasing.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1355]: https://bitwarden.atlassian.net/browse/BRE-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ