### PR TITLE
[PM-30667] Skip certbot cleanup prompt when non-interactive

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -322,6 +322,11 @@ function certbotCleanup() {
     # Check if the certbot image is being used by any containers
     if [[ -z $(docker ps -a --filter ancestor=certbot/certbot --quiet) ]]
     then
+        # Non-interactive execution (systemd/cron): do not prompt; keep image.
+        if ! [ -t 0 ]; then
+            return 0
+        fi
+        
         echo -e -n "${RED}(!) The [certbot/certbot] container image used by this script is no longer associated with any containers. Would you like to purge it? (y/N): ${NC}"
         read RESPONSE
         RESPONSE=$(echo "$RESPONSE" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## 🎟️ Tracking

Closes [https://github.com/bitwarden/self-host/issues/451](https://github.com/bitwarden/self-host/issues/451)
Community report (unattended/systemd context):
[https://community.bitwarden.com/t/self-hosted-error/92524](https://community.bitwarden.com/t/self-hosted-error/92524)

## 📔 Objective

Prevent certbotCleanup from prompting for input when stdin is not a TTY (e.g., systemd timers/cron). In unattended executions, the current prompt can block bitwarden.sh start/restart, leaving the instance stopped after automated tasks (e.g., backup jobs).

Implementation

Detect non-interactive execution via ! [ -t 0 ] in certbotCleanup.
When non-interactive: skip the prompt and keep the certbot/certbot image.
When interactive: preserve the existing prompt/behavior.

## ⏰ Reminders before review

- [x] Contributor guidelines followed
- [x] All formatters and local linters executed and passed (not applicable for shell script)
- [x] Written new unit and / or integration tests where applicable (not applicable for shell script)
- [x] Protected functional changes with optionality (feature flags) (not applicable)
- [x] Used internationalization (i18n) for all UI strings (not applicable; no UI changes)
- [ ] CI builds passed
- [x] Communicated to DevOps any deployment requirements (not applicable)
- [x] Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team (not applicable)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
