### PR TITLE
[bre-1525] QA lite environments pulling wrong web artifact

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -68,8 +68,6 @@ jobs:
     outputs:
       server_ref: ${{ steps.set-server-variables.outputs.server_ref }}
       web_ref: ${{ steps.set-web-variables.outputs.web_ref }}
-      web_branch_name: ${{ steps.set-web-variables.outputs.web_branch_name }}
-      use_web_release: ${{ steps.set-web-variables.outputs.use_web_release }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -105,18 +103,10 @@ jobs:
             WEB_VERSION=$(jq -r '.versions.webVersion' version.json)
             echo "Web version from version.json: $WEB_VERSION"
             echo "web_ref=refs/tags/web-v$WEB_VERSION" >> "$GITHUB_OUTPUT"
-            echo "web_branch_name=" >> "$GITHUB_OUTPUT"
-            echo "use_web_release=true" >> "$GITHUB_OUTPUT"
           elif [[ -z "${WEB_BRANCH}" ]]; then
             echo "web_ref=refs/heads/main" >> "$GITHUB_OUTPUT"
-            echo "web_branch_name=main" >> "$GITHUB_OUTPUT"
-            echo "use_web_release=false" >> "$GITHUB_OUTPUT"
           else
-            # Strip refs/heads/ prefix if present
-            CLEAN_BRANCH="${WEB_BRANCH#refs/heads/}"
-            echo "web_ref=refs/heads/${CLEAN_BRANCH}" >> "$GITHUB_OUTPUT"
-            echo "web_branch_name=${CLEAN_BRANCH}" >> "$GITHUB_OUTPUT"
-            echo "use_web_release=false" >> "$GITHUB_OUTPUT"
+            echo "web_ref=refs/heads/${WEB_BRANCH#refs/heads/}" >> "$GITHUB_OUTPUT"
           fi
 
   build-docker:
@@ -211,31 +201,21 @@ jobs:
           persist-credentials: false
 
       - name: Download web client branch artifacts for dev builds
-        if: needs.setup.outputs.use_web_release == 'false'
+        if: ${{ !inputs.use_latest_web_version }}
         uses: bitwarden/gh-actions/download-artifacts@main
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           workflow: build-web.yml
           workflow_conclusion: success
-          branch: ${{ needs.setup.outputs.web_branch_name }}
+          branch: ${{ needs.setup.outputs.web_ref }}
           repo: bitwarden/clients
           artifacts: "web-*-selfhosted-DEV.zip"
           if_no_artifact_found: fail
 
       - name: Set web artifact path for dev builds
-        if: needs.setup.outputs.use_web_release == 'false'
+        if: ${{ !inputs.use_latest_web_version }}
         id: set-web-artifact-path
-        env:
-          WEB_BRANCH_NAME: ${{ needs.setup.outputs.web_branch_name }}
-        run: |
-          WEB_ARTIFACT=$(find . -name "web-*-selfhosted-DEV.zip" | head -1)
-          if [[ -z "${WEB_ARTIFACT}" ]]; then
-            echo "ERROR: No web artifact found for branch: ${WEB_BRANCH_NAME}"
-            echo "Make sure the build-web.yml workflow has completed successfully for this branch"
-            exit 1
-          fi
-          echo "path=${WEB_ARTIFACT}" >> "$GITHUB_OUTPUT"
-          echo "Found web artifact: ${WEB_ARTIFACT}"
+        run: echo "path=$(find . -name "web-*-selfhosted-DEV.zip" | head -1)" >> "$GITHUB_OUTPUT"
 
       - name: Log build configuration
         env:


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1525](https://bitwarden.atlassian.net/browse/bre-1525)

## 📔 Objective

_solution has been optimized by @vgrassia's PR #460_

Fixes a bug where specifying a non-main web branch (e.g., `rc`, feature branches) would fail to download DEV artifacts and silently fall back to downloading COMMERCIAL releases, causing server/web version mismatches. The artifact download step now triggers for all branch builds (not just main), downloads from the specified branch dynamically, and fails immediately with a clear error if artifacts are not found. Production releases using `use_latest_web_version: true` continue to work as before.

_expected functionality with these changes:_

### Check boxes enabled (use_latest_core_version + use_latest_web_version):
  - Downloads latest production COMMERCIAL releases from version.json
  - Image uses stable release versions

### Entering branch names (e.g., server_branch: rc, web_branch: rc):
  - Builds from those specific branches
  - Downloads DEV artifacts from those branches
  - Fails immediately with clear error if branch has no artifacts

### Leaving everything blank/default:
  - Defaults to main branch for both server and web
  - Downloads DEV artifacts from main branch
  - Creates ghcr.io/bitwarden/lite:dev image

### workflow_call from release-self-host:
  - Passes use_latest_*: true flags
  - Continues to download COMMERCIAL releases exactly as before
  - No change to production release behavior