### PR TITLE
Fix marketplace image versioning by passing release version from release pipeline

### DIFF
--- a/.github/workflows/release-aws.yml
+++ b/.github/workflows/release-aws.yml
@@ -7,6 +7,11 @@ on:
       - "CommonMarketplace/**"
 
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release version (e.g., 2026.3.2)"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -47,7 +52,7 @@ jobs:
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
-      - name: Set version from version.json
+      - name: Set version
         id: set-version
         run: |
           VERSION=$(jq -r '.versions.coreVersion' version.json)
@@ -57,6 +62,14 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+          # Use the release version input when dispatched from the release
+          # pipeline. Fall back to coreVersion for other builds.
+          if [[ -n "${{ inputs.release_version }}" ]]; then
+            echo "img_version=${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "img_version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Hashicorp Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # v3.1.0
 
@@ -65,7 +78,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-marketplace-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-marketplace-secret-access-key }}
           AWS_DEFAULT_REGION: "us-east-1"
-          AWS_IMG_VERSION: ${{ steps.set-version.outputs.version }}
+          AWS_IMG_VERSION: ${{ steps.set-version.outputs.img_version }}
         working-directory: ./AWSMarketplace
         run: |
           packer version
@@ -135,7 +148,7 @@ jobs:
 
       - name: AWS Image Cleanup
         working-directory: ./AWSMarketplace
-        if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ inputs.release_version == '' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.retrieve-secrets.outputs.aws-marketplace-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.retrieve-secrets.outputs.aws-marketplace-secret-access-key }}

--- a/.github/workflows/release-aws.yml
+++ b/.github/workflows/release-aws.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Set version
         id: set-version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
           VERSION=$(jq -r '.versions.coreVersion' version.json)
           if [[ -z "$VERSION" ]]; then
@@ -64,8 +66,8 @@ jobs:
 
           # Use the release version input when dispatched from the release
           # pipeline. Fall back to coreVersion for other builds.
-          if [[ -n "${{ inputs.release_version }}" ]]; then
-            echo "img_version=${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+          if [[ -n "$RELEASE_VERSION" ]]; then
+            echo "img_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           else
             echo "img_version=$VERSION" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release-azure.yml
+++ b/.github/workflows/release-azure.yml
@@ -53,12 +53,13 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Use a dev version for non-release builds to avoid colliding with
-          # published gallery image versions
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "img_version=$VERSION" >> "$GITHUB_OUTPUT"
-          else
+          # Use a dev version for push builds to avoid colliding with
+          # published gallery image versions. workflow_dispatch is used by
+          # the release pipeline, so it should use the real version.
+          if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "img_version=0.0.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "img_version=$VERSION" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Hashicorp Packer

--- a/.github/workflows/release-azure.yml
+++ b/.github/workflows/release-azure.yml
@@ -7,6 +7,11 @@ on:
       - "CommonMarketplace/**"
 
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release version (e.g., 2026.3.2)"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -43,7 +48,7 @@ jobs:
           keyvault: "gh-self-host"
           secrets: "azure-marketplace-subscription-id"
 
-      - name: Set version from version.json
+      - name: Set version
         id: set-version
         run: |
           VERSION=$(jq -r '.versions.coreVersion' version.json)
@@ -53,13 +58,13 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Use a dev version for push builds to avoid colliding with
-          # published gallery image versions. workflow_dispatch is used by
-          # the release pipeline, so it should use the real version.
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "img_version=0.0.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          # Use the release version input when dispatched from the release
+          # pipeline. Fall back to a dev version for push builds to avoid
+          # colliding with published gallery image versions.
+          if [[ -n "${{ inputs.release_version }}" ]]; then
+            echo "img_version=${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
           else
-            echo "img_version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "img_version=0.0.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Hashicorp Packer
@@ -135,7 +140,7 @@ jobs:
 
       - name: Azure Image Cleanup
         working-directory: ./AzureMarketplace
-        if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ inputs.release_version == '' }}
         env:
           RESOURCE_GROUP: rg-marketplace
           GALLERY_NAME: bitwarden_marketplace

--- a/.github/workflows/release-azure.yml
+++ b/.github/workflows/release-azure.yml
@@ -50,6 +50,9 @@ jobs:
 
       - name: Set version
         id: set-version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           VERSION=$(jq -r '.versions.coreVersion' version.json)
           if [[ -z "$VERSION" ]]; then
@@ -61,10 +64,10 @@ jobs:
           # Use the release version input when dispatched from the release
           # pipeline. Fall back to a dev version for push builds to avoid
           # colliding with published gallery image versions.
-          if [[ -n "${{ inputs.release_version }}" ]]; then
-            echo "img_version=${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+          if [[ -n "$RELEASE_VERSION" ]]; then
+            echo "img_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "img_version=0.0.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+            echo "img_version=0.0.$RUN_NUMBER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Hashicorp Packer

--- a/.github/workflows/release-digital-ocean.yml
+++ b/.github/workflows/release-digital-ocean.yml
@@ -7,6 +7,11 @@ on:
       - "CommonMarketplace/**"
 
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release version (e.g., 2026.3.2)"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -46,7 +51,7 @@ jobs:
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
-      - name: Set version from version.json
+      - name: Set version
         id: set-version
         run: |
           VERSION=$(jq -r '.versions.coreVersion' version.json)
@@ -56,13 +61,21 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+          # Use the release version input when dispatched from the release
+          # pipeline. Fall back to coreVersion for other builds.
+          if [[ -n "${{ inputs.release_version }}" ]]; then
+            echo "img_version=${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "img_version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Hashicorp Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # v3.1.0
 
       - name: Build Digital Ocean Image
         env:
           DIGITALOCEAN_TOKEN: ${{ steps.retrieve-secrets.outputs.digital-ocean-api-key }}
-          DIGITALOCEAN_IMG_VERSION: ${{ steps.set-version.outputs.version }}
+          DIGITALOCEAN_IMG_VERSION: ${{ steps.set-version.outputs.img_version }}
         working-directory: ./DigitalOceanMarketplace
         run: |
           packer version
@@ -138,7 +151,7 @@ jobs:
 
       - name: Digital Ocean Image Cleanup
         working-directory: ./DigitalOceanMarketplace
-        if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ inputs.release_version == '' }}
         run: |
           # Get the ID from the snapshot build.
           DO_ARTIFACT=$(jq -r '.builds[-1].artifact_id' manifest.json | cut -d ":" -f2)

--- a/.github/workflows/release-digital-ocean.yml
+++ b/.github/workflows/release-digital-ocean.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Set version
         id: set-version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
           VERSION=$(jq -r '.versions.coreVersion' version.json)
           if [[ -z "$VERSION" ]]; then
@@ -63,8 +65,8 @@ jobs:
 
           # Use the release version input when dispatched from the release
           # pipeline. Fall back to coreVersion for other builds.
-          if [[ -n "${{ inputs.release_version }}" ]]; then
-            echo "img_version=${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+          if [[ -n "$RELEASE_VERSION" ]]; then
+            echo "img_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           else
             echo "img_version=$VERSION" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,6 +495,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           RELEASE_TAG: v${{ inputs.release_version }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -503,13 +504,14 @@ jobs:
               repo: 'self-host',
               workflow_id: 'release-digital-ocean.yml',
               ref: process.env.RELEASE_TAG,
-              inputs: {}
+              inputs: { release_version: process.env.RELEASE_VERSION }
             });
 
       - name: Trigger release-aws workflow
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           RELEASE_TAG: v${{ inputs.release_version }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -518,13 +520,14 @@ jobs:
               repo: 'self-host',
               workflow_id: 'release-aws.yml',
               ref: process.env.RELEASE_TAG,
-              inputs: {}
+              inputs: { release_version: process.env.RELEASE_VERSION }
             });
 
       - name: Trigger release-azure workflow
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           RELEASE_TAG: v${{ inputs.release_version }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -533,5 +536,5 @@ jobs:
               repo: 'self-host',
               workflow_id: 'release-azure.yml',
               ref: process.env.RELEASE_TAG,
-              inputs: {}
+              inputs: { release_version: process.env.RELEASE_VERSION }
             });


### PR DESCRIPTION
- Fix marketplace workflows using incorrect versions during releases — Azure published 0.0.15 instead of 2026.3.2 because the event name check (== "release") never matched (workflows are triggered via workflow_dispatch)
- Pass release_version input from release.yml to all three marketplace workflows (AWS, Azure, DigitalOcean) so image versions match the self-host release version, not coreVersion from version.json
- Update image cleanup conditions to key off inputs.release_version instead of the unreachable github.event_name != 'release' check