### PR TITLE
SHOT-139: Fix git metadata missing from dev builds

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -174,6 +174,7 @@ jobs:
         run: |
           if [[ $WEB_REF =~ ^refs/tags/web-v(.+)$ ]]; then
             WEB_TAG="${BASH_REMATCH[1]}"
+            WEB_IMAGE="ghcr.io/bitwarden/web"
           else
             WEB_TAG=$(echo "${WEB_REF#refs/heads/}" | \
               tr '[:upper:]' '[:lower:]' | \
@@ -181,17 +182,20 @@ jobs:
               cut -c1-128 | \
               sed -E 's/[.-]$//')
             [[ "$WEB_TAG" == "main" ]] && WEB_TAG=dev
+            WEB_IMAGE="ghcr.io/bitwarden/web-dev"
           fi
           echo "web_tag=${WEB_TAG}" >> "$GITHUB_OUTPUT"
+          echo "web_image=${WEB_IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Log build configuration
         env:
           SERVER_TAG: ${{ steps.tag.outputs.image_tag }}
+          WEB_IMAGE: ${{ steps.web-tag.outputs.web_image }}
           WEB_TAG: ${{ steps.web-tag.outputs.web_tag }}
         run: |
           echo "### Build Configuration" >> $GITHUB_STEP_SUMMARY
           echo "- Server: ghcr.io/bitwarden/\*:${SERVER_TAG}" >> $GITHUB_STEP_SUMMARY
-          echo "- Web: ghcr.io/bitwarden/web:${WEB_TAG}" >> $GITHUB_STEP_SUMMARY
+          echo "- Web: ${WEB_IMAGE}:${WEB_TAG}" >> $GITHUB_STEP_SUMMARY
 
       - name: Build and push Docker image
         id: build-docker
@@ -207,6 +211,7 @@ jobs:
           tags: ghcr.io/bitwarden/lite:${{ steps.tag.outputs.image_tag }}
           build-args: |
             SERVER_TAG=${{ steps.tag.outputs.image_tag }}
+            WEB_IMAGE=${{ steps.web-tag.outputs.web_image }}
             WEB_TAG=${{ steps.web-tag.outputs.web_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=min

--- a/bitwarden-lite/Dockerfile
+++ b/bitwarden-lite/Dockerfile
@@ -1,11 +1,12 @@
 # syntax = docker/dockerfile:1.21
 ARG SERVER_TAG=dev
+ARG WEB_IMAGE=ghcr.io/bitwarden/web
 ARG WEB_TAG=dev
 
 ###############################################
 #              Web app stage                  #
 ###############################################
-FROM ghcr.io/bitwarden/web:${WEB_TAG} AS web-app
+FROM ${WEB_IMAGE}:${WEB_TAG} AS web-app
 
 ###############################################
 #              Server app stages              #


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/SHOT-139
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Regression introduced in https://github.com/bitwarden/self-host/pull/480, which removed the git metadata for dev and rc builds. This corrects this by adding a build arg for the web container image, then dynamically setting it based on build source, defaulting to `ghcr.io/bitwarden/web`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
