### PR TITLE
[SHOT-148] fix: syntax error in BUILT_IN_MS_SQL_ENABLED conditional check

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -202,6 +202,7 @@ function updateDatabase() {
 
 function updatebw() {
     KEY_CONNECTOR_ENABLED=$(grep 'enable_key_connector:' $OUTPUT_DIR/config.yml | awk '{ print $2}')
+    BUILT_IN_MS_SQL_ENABLED=$(grep 'enable_built_in_ms_sql:' $OUTPUT_DIR/config.yml | awk '{ print $2}')
     CORE_ID=$($dccmd ps -q admin)
     WEB_ID=$($dccmd ps -q web)
     if [ "$KEY_CONNECTOR_ENABLED" = true ];
@@ -227,8 +228,12 @@ function updatebw() {
     update withpull
     restart
     dockerPrune
-    echo "Pausing 60 seconds for database to come online. Please wait..."
-    sleep 60
+
+    if [ "$BUILT_IN_MS_SQL_ENABLED" = true ];
+    then
+        echo "Pausing 60 seconds for database to come online. Please wait..."
+        sleep 60
+    fi
 }
 
 function update() {

--- a/run.sh
+++ b/run.sh
@@ -229,7 +229,7 @@ function updatebw() {
     restart
     dockerPrune
 
-    if [ "$BUILT_IN_MS_SQL_ENABLED" = true ];
+    if [ "$BUILT_IN_MS_SQL_ENABLED" != false ];
     then
         echo "Pausing 60 seconds for database to come online. Please wait..."
         sleep 60


### PR DESCRIPTION
## 🎟️ Tracking
Discovered during automated AWX playbook runs — the unconditional 60-second sleep was causing unnecessary delays on deployments using an external database.

## 📔 Objective
The `updatebw` function in `run.sh` unconditionally sleeps 60 seconds after an update to wait for MSSQL to come online. This is unnecessary for users running an external database. This PR adds a conditional check so the 60-second sleep only occurs when `enable_built_in_ms_sql` is set to `true` in `config.yml`. The `BUILT_IN_MS_SQL_ENABLED` variable is read from the config and used to gate the sleep, matching the pattern already used for `enable_key_connector`.

## ⏰ Reminders before review
- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines
- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
