### PR TITLE
BRE-1893 fix(azure-marketplace): resolve certification failures

### DIFF
--- a/AzureMarketplace/marketplace-image.pkr.hcl
+++ b/AzureMarketplace/marketplace-image.pkr.hcl
@@ -174,16 +174,12 @@ build {
     ]
   }
 
-  # Upgrade Azure Linux Agent from Microsoft's package repository to meet minimum version requirement
   provisioner "shell" {
-    environment_vars = [
-      "DEBIAN_FRONTEND=noninteractive",
-    ]
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
     inline = [
-      "curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg",
-      "echo \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main\" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list > /dev/null",
-      "sudo apt-get -qqy update",
-      "sudo apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install walinuxagent"
+      "sudo apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install walinuxagent",
+      "sudo systemctl enable walinuxagent",
+      "waagent --version",
     ]
   }
 
@@ -207,9 +203,14 @@ build {
 
   # Azure-specific cleanup
   provisioner "shell" {
-    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    environment_vars = [
+      "HISTFILE=/dev/null",
+      "HISTSIZE=0",
+    ]
     inline = [
-      "truncate -s 0 /var/log/waagent.log 2>/dev/null || true"
+      "truncate -s 0 /var/log/waagent.log 2>/dev/null || true",
+      "find / -xdev -name '.bash_history' -type f -delete 2>/dev/null || true",
     ]
   }
 

--- a/AzureMarketplace/scripts/99-img-check.sh
+++ b/AzureMarketplace/scripts/99-img-check.sh
@@ -2,6 +2,10 @@
 
 # Azure Marketplace Image Validation Tool
 
+# Prevent this script from writing to bash history
+unset HISTFILE
+export HISTSIZE=0
+
 VERSION="v. 1.0.0"
 RUNDATE=$( date )
 
@@ -69,6 +73,16 @@ if hash waagent 2>/dev/null; then
   fi
 else
   echo -en "\e[41m[FAIL]\e[0m Azure Linux Agent (waagent) is not installed.\n"
+  ((FAIL++))
+  STATUS=2
+fi
+
+# Check Azure Linux Agent service is enabled (will start on the deployed VM)
+if systemctl is-enabled walinuxagent >/dev/null 2>&1; then
+  echo -en "\e[32m[PASS]\e[0m Azure Linux Agent service is enabled.\n"
+  ((PASS++))
+else
+  echo -en "\e[41m[FAIL]\e[0m Azure Linux Agent service is not enabled.\n"
   ((FAIL++))
   STATUS=2
 fi
@@ -142,7 +156,7 @@ else
 fi
 
 # Check SSH ClientAliveInterval (Azure requirement: 30-235 seconds)
-ALIVE_INTERVAL=$(grep -i "^ClientAliveInterval" /etc/ssh/sshd_config | awk '{print $2}' | tail -1)
+ALIVE_INTERVAL=$(sshd -T 2>/dev/null | awk '/^clientaliveinterval/{print $2}')
 if [[ -n "${ALIVE_INTERVAL}" ]] && [[ "${ALIVE_INTERVAL}" -ge 30 ]] && [[ "${ALIVE_INTERVAL}" -le 235 ]]; then
   echo -en "\e[32m[PASS]\e[0m SSH ClientAliveInterval is ${ALIVE_INTERVAL} seconds (30-235 required).\n"
   ((PASS++))
@@ -163,20 +177,24 @@ else
   STATUS=2
 fi
 
-# Check bash history
-if [ -f /root/.bash_history ]; then
-  BH_S=$(wc -c < /root/.bash_history)
-  if [[ $BH_S -lt 200 ]]; then
-    echo -en "\e[32m[PASS]\e[0m Root bash history appears cleared.\n"
-    ((PASS++))
-  else
-    echo -en "\e[41m[FAIL]\e[0m Root bash history should be cleared.\n"
-    ((FAIL++))
-    STATUS=2
-  fi
-else
-  echo -en "\e[32m[PASS]\e[0m Root bash history is not present.\n"
+# Check waagent will not recreate swap on first boot of the deployed VM.
+if [ -f /etc/waagent.conf ] && grep -q "^ResourceDisk.EnableSwap=n" /etc/waagent.conf; then
+  echo -en "\e[32m[PASS]\e[0m waagent ResourceDisk.EnableSwap is disabled.\n"
   ((PASS++))
+else
+  echo -en "\e[41m[FAIL]\e[0m waagent will recreate swap on first boot (ResourceDisk.EnableSwap is not 'n').\n"
+  ((FAIL++))
+  STATUS=2
+fi
+
+# Check bash history — Azure tests for file existence, not size.
+if [ ! -f /root/.bash_history ] && [ ! -f /home/ubuntu/.bash_history ]; then
+  echo -en "\e[32m[PASS]\e[0m No bash history files present.\n"
+  ((PASS++))
+else
+  echo -en "\e[41m[FAIL]\e[0m bash history file present (must be deleted, not truncated).\n"
+  ((FAIL++))
+  STATUS=2
 fi
 
 # Check cloud-init first-boot script is present and executable

--- a/CommonMarketplace/scripts/90-cleanup.sh
+++ b/CommonMarketplace/scripts/90-cleanup.sh
@@ -4,6 +4,10 @@
 
 set -o errexit
 
+# Prevent this script from writing to bash history
+unset HISTFILE
+export HISTSIZE=0
+
 # Ensure /tmp exists and has the proper permissions
 if [ ! -d /tmp ]; then
   mkdir /tmp
@@ -18,19 +22,35 @@ if [ -n "$(command -v apt-get)" ]; then
   apt-get -y autoclean
 fi
 
-# Disable swap (marketplace requirement: no swap on OS disk)
+# Disable swap (marketplace requirement: no swap on OS disk).
+# Build-time: clear current swap and fstab.
 swapoff -a 2>/dev/null || true
 sed -i '/\bswap\b/d' /etc/fstab
 if [ -f /swapfile ]; then
   rm -f /swapfile
 fi
-
-# Configure SSH client alive interval (Azure requirement: 30-235 seconds)
-if grep -q "^#*\s*ClientAliveInterval" /etc/ssh/sshd_config; then
-  sed -i 's/^#*\s*ClientAliveInterval.*/ClientAliveInterval 120/' /etc/ssh/sshd_config
-else
-  echo "ClientAliveInterval 120" >> /etc/ssh/sshd_config
+# Boot-time: tell waagent not to create resource-disk swap on first boot.
+if [ -f /etc/waagent.conf ]; then
+  sed -i 's/^ResourceDisk\.EnableSwap=.*/ResourceDisk.EnableSwap=n/' /etc/waagent.conf
+  sed -i 's/^ResourceDisk\.SwapSizeMB=.*/ResourceDisk.SwapSizeMB=0/' /etc/waagent.conf
 fi
+# Boot-time: tell cloud-init not to create /swap.img.
+cat > /etc/cloud/cloud.cfg.d/99-disable-swap.cfg <<'EOF'
+swap:
+  filename: /swap.img
+  size: 0
+  maxsize: 0
+EOF
+chmod 644 /etc/cloud/cloud.cfg.d/99-disable-swap.cfg
+
+# Configure SSH client alive interval (Azure requirement: 30-235 seconds).
+# Use a drop-in that sorts before /etc/ssh/sshd_config.d/50-cloud-init.conf so
+# this setting wins — sshd uses the first occurrence of each directive.
+cat > /etc/ssh/sshd_config.d/10-azure-marketplace.conf <<'EOF'
+ClientAliveInterval 120
+ClientAliveCountMax 3
+EOF
+chmod 644 /etc/ssh/sshd_config.d/10-azure-marketplace.conf
 
 rm -rf /tmp/* /var/tmp/*
 


### PR DESCRIPTION

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BRE-1893](https://bitwarden.atlassian.net/browse/BRE-1893)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


Address Azure Marketplace certification failures from the 2026.4.1 release submission.
* ClientAliveInterval (200.3.3.1): write the setting to /etc/ssh/sshd_config.d/10-azure-marketplace.conf so it wins over cloud-init's drop-in. Validator reads sshd -T to match what Azure tests.
* No swap on OS disk (200.3.3.3): set ResourceDisk.EnableSwap=n in /etc/waagent.conf and drop a cloud-init swap module so swap is not recreated on first boot. Validator asserts the waagent.conf setting.
* Linux Agent (200.3.3.4): explicitly install walinuxagent from noble-updates and systemctl enable it so the agent reports to the Azure fabric on first boot. Validator adds an is-enabled check.
* Bash history (200.5.1): delete .bash_history in the final packer provisioner with HISTFILE=/dev/null so subsequent steps do not repopulate it. Validator checks for file absence.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1893]: https://bitwarden.atlassian.net/browse/BRE-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ