### PR TITLE
BRE-1893 fix(azure-marketplace): correct validator and history cleanup

### DIFF
--- a/AzureMarketplace/scripts/99-img-check.sh
+++ b/AzureMarketplace/scripts/99-img-check.sh
@@ -20,7 +20,6 @@ PASS=0
 WARN=0
 FAIL=0
 
-clear
 echo "Azure Marketplace Image Validation Tool ${VERSION}"
 echo "Executed on: ${RUNDATE}"
 echo "Checking local system for Marketplace compatibility..."
@@ -156,7 +155,8 @@ else
 fi
 
 # Check SSH ClientAliveInterval (Azure requirement: 30-235 seconds)
-ALIVE_INTERVAL=$(sshd -T 2>/dev/null | awk '/^clientaliveinterval/{print $2}')
+ALIVE_INTERVAL=$(sshd -T -C user=root,host=localhost,addr=127.0.0.1 2>/dev/null \
+  | awk '/^clientaliveinterval/{print $2}')
 if [[ -n "${ALIVE_INTERVAL}" ]] && [[ "${ALIVE_INTERVAL}" -ge 30 ]] && [[ "${ALIVE_INTERVAL}" -le 235 ]]; then
   echo -en "\e[32m[PASS]\e[0m SSH ClientAliveInterval is ${ALIVE_INTERVAL} seconds (30-235 required).\n"
   ((PASS++))

--- a/CommonMarketplace/scripts/90-cleanup.sh
+++ b/CommonMarketplace/scripts/90-cleanup.sh
@@ -59,7 +59,7 @@ unset HISTFILE
 export HISTSIZE=0
 for home_dir in /root /home/*; do
   if [ -d "$home_dir" ]; then
-    cat /dev/null > "$home_dir/.bash_history" 2>/dev/null || true
+    rm -f "$home_dir/.bash_history" 2>/dev/null || true
   fi
 done
 


### PR DESCRIPTION






## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BRE-1893](https://bitwarden.atlassian.net/browse/BRE-1893)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix two validator steps surfaced by the marketplace build run after the initial certification fixes were applied.
* Provide sshd -T with an explicit connection context so it returns the effective ClientAliveInterval instead of empty output on noble.
* Delete .bash_history files in `90-cleanup.sh` instead of truncating, so the validator's file-absent check matches what Azure tests.
* Remove clear call from the validator

Related to https://github.com/bitwarden/self-host/pull/504
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1893]: https://bitwarden.atlassian.net/browse/BRE-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ