### PR TITLE
BRE-1893 fix(marketplace): defer host-key removal

### DIFF
--- a/AWSMarketplace/marketplace-image.pkr.hcl
+++ b/AWSMarketplace/marketplace-image.pkr.hcl
@@ -177,7 +177,8 @@ build {
       "../CommonMarketplace/scripts/01-setup-first-run.sh",
       "../CommonMarketplace/scripts/02-ufw-bitwarden.sh",
       "../CommonMarketplace/scripts/90-cleanup.sh",
-      "scripts/99-img-check.sh"
+      "scripts/99-img-check.sh",
+      "../CommonMarketplace/scripts/99-cleanup-final.sh"
     ]
   }
 

--- a/AzureMarketplace/marketplace-image.pkr.hcl
+++ b/AzureMarketplace/marketplace-image.pkr.hcl
@@ -197,7 +197,8 @@ build {
       "../CommonMarketplace/scripts/01-setup-first-run.sh",
       "../CommonMarketplace/scripts/02-ufw-bitwarden.sh",
       "../CommonMarketplace/scripts/90-cleanup.sh",
-      "scripts/99-img-check.sh"
+      "scripts/99-img-check.sh",
+      "../CommonMarketplace/scripts/99-cleanup-final.sh"
     ]
   }
 

--- a/CommonMarketplace/scripts/90-cleanup.sh
+++ b/CommonMarketplace/scripts/90-cleanup.sh
@@ -46,11 +46,11 @@ chmod 644 /etc/cloud/cloud.cfg.d/99-disable-swap.cfg
 # Configure SSH client alive interval (Azure requirement: 30-235 seconds).
 # Use a drop-in that sorts before /etc/ssh/sshd_config.d/50-cloud-init.conf so
 # this setting wins — sshd uses the first occurrence of each directive.
-cat > /etc/ssh/sshd_config.d/10-azure-marketplace.conf <<'EOF'
+cat > /etc/ssh/sshd_config.d/10-bitwarden-marketplace.conf <<'EOF'
 ClientAliveInterval 120
 ClientAliveCountMax 3
 EOF
-chmod 644 /etc/ssh/sshd_config.d/10-azure-marketplace.conf
+chmod 644 /etc/ssh/sshd_config.d/10-bitwarden-marketplace.conf
 
 rm -rf /tmp/* /var/tmp/*
 
@@ -66,6 +66,4 @@ done
 find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
 rm -rf /var/lib/cloud/instances/*
-rm -f /root/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys /etc/ssh/*key*
-touch /etc/ssh/revoked_keys
-chmod 600 /etc/ssh/revoked_keys
+rm -f /root/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys

--- a/CommonMarketplace/scripts/99-cleanup-final.sh
+++ b/CommonMarketplace/scripts/99-cleanup-final.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Marketplace Image Final Cleanup
+#
+# Destructive operations that must run AFTER the validator (99-img-check.sh).
+# Host-key removal in particular breaks `sshd -T`, which the validator uses to
+# read the effective sshd config. Keep this script destructive-only; config
+# writes belong in 90-cleanup.sh.
+
+set -o errexit
+
+# Prevent this script from writing to bash history
+unset HISTFILE
+export HISTSIZE=0
+
+# Remove sshd host keys so each marketplace customer's VM regenerates unique
+# keys on first boot. revoked_keys must exist or sshd will fail to start.
+rm -f /etc/ssh/ssh_host_*
+touch /etc/ssh/revoked_keys
+chmod 600 /etc/ssh/revoked_keys

--- a/DigitalOceanMarketplace/marketplace-image.pkr.hcl
+++ b/DigitalOceanMarketplace/marketplace-image.pkr.hcl
@@ -137,7 +137,8 @@ build {
       "../CommonMarketplace/scripts/01-setup-first-run.sh",
       "../CommonMarketplace/scripts/02-ufw-bitwarden.sh",
       "../CommonMarketplace/scripts/90-cleanup.sh",
-      "scripts/99-img-check.sh"
+      "scripts/99-img-check.sh",
+      "../CommonMarketplace/scripts/99-cleanup-final.sh"
     ]
   }
 


### PR DESCRIPTION




## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BRE-1893](https://bitwarden.atlassian.net/browse/BRE-1893)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The Azure validator (99-img-check.sh) calls `sshd -T` to read the effective sshd config, but 90-cleanup.sh was removing /etc/ssh host keys earlier in the same provisioner. Without host keys `sshd -T` fails silently, the `ClientAliveInterval` check sees empty output, and the build fails after the config writes were correct.

Split the destructive ssh host-key removal into a new 99-cleanup-final.sh that runs after the validator. AWS and DO marketplace builds get the new script in their scripts arrays too so final-image state is unchanged for them.
* Move ssh_host_* removal and revoked_keys creation out of 90-cleanup.sh into a new CommonMarketplace/scripts/99-cleanup-final.sh
* Tighten the host-key glob from /etc/ssh/*key* to /etc/ssh/ssh_host_*
* Rename sshd drop-in from 10-azure-marketplace.conf to 10-bitwarden-marketplace.conf since 90-cleanup.sh is shared across Azure, AWS, and DO builds
* Add 99-cleanup-final.sh to the scripts array in all three marketplace packer files


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1893]: https://bitwarden.atlassian.net/browse/BRE-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ