### PR TITLE
[bre-1901] add ACR optionality into dockerfile

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -185,16 +185,19 @@ jobs:
         run: |
           if [[ $SERVER_REF =~ ^refs/tags/v(.+)$ ]]; then
               IMAGE_TAG="${BASH_REMATCH[1]}"
+              SERVER_TAG="${BASH_REMATCH[1]}"
           else
               IMAGE_TAG=$(echo "${SERVER_REF#refs/heads/}" | \
               tr '[:upper:]' '[:lower:]' | \
               sed -E 's/[^a-z0-9._-]+/-/g; s/-+/-/g; s/^-+|-+$//g' | \
               cut -c1-128 | \
               sed -E 's/[.-]$//')
+              SERVER_TAG=$(echo "${SERVER_REF#refs/heads/}" | sed 's|/|-|g' | cut -c1-128)
           fi
 
           if [[ "$IMAGE_TAG" == "main" ]]; then
             IMAGE_TAG=dev
+            SERVER_TAG=dev
           fi
 
           if [[ -z "$IMAGE_TAG" ]]; then
@@ -202,8 +205,9 @@ jobs:
             exit 1
           fi
 
-          echo "Using $IMAGE_TAG for build"
+          echo "Using lite tag $IMAGE_TAG, server tag $SERVER_TAG"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "server_tag=${SERVER_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Generate web image tag
         id: web-tag
@@ -241,11 +245,14 @@ jobs:
       - name: Log build configuration
         env:
           IMAGE_TAGS: ${{ steps.image-ref.outputs.tags }}
+          SERVER_REGISTRY: ${{ needs.setup.outputs.push_to_ghcr == 'true' && 'ghcr.io/bitwarden' || 'bitwardenprod.azurecr.io' }}
+          SERVER_TAG: ${{ steps.tag.outputs.server_tag }}
           WEB_IMAGE: ${{ steps.web-tag.outputs.web_image }}
           WEB_TAG: ${{ steps.web-tag.outputs.web_tag }}
         run: |
           echo "### Build Configuration" >> $GITHUB_STEP_SUMMARY
           echo "- Lite: ${IMAGE_TAGS}" >> $GITHUB_STEP_SUMMARY
+          echo "- Server: ${SERVER_REGISTRY}/*:${SERVER_TAG}" >> $GITHUB_STEP_SUMMARY
           echo "- Web: ${WEB_IMAGE}:${WEB_TAG}" >> $GITHUB_STEP_SUMMARY
 
       - name: Build and push Docker image
@@ -261,7 +268,8 @@ jobs:
           push: ${{ steps.check-secrets.outputs.has_secrets == 'true' }}
           tags: ${{ steps.image-ref.outputs.tags }}
           build-args: |
-            SERVER_TAG=${{ steps.tag.outputs.image_tag }}
+            SERVER_TAG=${{ steps.tag.outputs.server_tag }}
+            SERVER_REGISTRY=${{ needs.setup.outputs.push_to_ghcr == 'true' && 'ghcr.io/bitwarden' || 'bitwardenprod.azurecr.io' }}
             WEB_IMAGE=${{ steps.web-tag.outputs.web_image }}
             WEB_TAG=${{ steps.web-tag.outputs.web_tag }}
 

--- a/bitwarden-lite/Dockerfile
+++ b/bitwarden-lite/Dockerfile
@@ -1,5 +1,6 @@
 # syntax = docker/dockerfile:1.23
 ARG SERVER_TAG=dev
+ARG SERVER_REGISTRY=ghcr.io/bitwarden
 ARG WEB_IMAGE=ghcr.io/bitwarden/web
 ARG WEB_TAG=dev
 
@@ -11,14 +12,14 @@ FROM ${WEB_IMAGE}:${WEB_TAG} AS web-app
 ###############################################
 #              Server app stages              #
 ###############################################
-FROM ghcr.io/bitwarden/admin:${SERVER_TAG} AS admin-app
-FROM ghcr.io/bitwarden/api:${SERVER_TAG} AS api-app
-FROM ghcr.io/bitwarden/events:${SERVER_TAG} AS events-app
-FROM ghcr.io/bitwarden/icons:${SERVER_TAG} AS icons-app
-FROM ghcr.io/bitwarden/identity:${SERVER_TAG} AS identity-app
-FROM ghcr.io/bitwarden/notifications:${SERVER_TAG} AS notifications-app
-FROM ghcr.io/bitwarden/scim:${SERVER_TAG} AS scim-app
-FROM ghcr.io/bitwarden/sso:${SERVER_TAG} AS sso-app
+FROM ${SERVER_REGISTRY}/admin:${SERVER_TAG} AS admin-app
+FROM ${SERVER_REGISTRY}/api:${SERVER_TAG} AS api-app
+FROM ${SERVER_REGISTRY}/events:${SERVER_TAG} AS events-app
+FROM ${SERVER_REGISTRY}/icons:${SERVER_TAG} AS icons-app
+FROM ${SERVER_REGISTRY}/identity:${SERVER_TAG} AS identity-app
+FROM ${SERVER_REGISTRY}/notifications:${SERVER_TAG} AS notifications-app
+FROM ${SERVER_REGISTRY}/scim:${SERVER_TAG} AS scim-app
+FROM ${SERVER_REGISTRY}/sso:${SERVER_TAG} AS sso-app
 
 ###############################################
 #                  App stage                  #


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1901](https://bitwarden.atlassian.net/browse/bre-1901)

## 📔 Objective

currently our server builds trigger a build bitwarden lite run, but they are hardcoded to look at GHCR for images. This creates optionality for non main, rc, hotfix-* builds to pull from ACR
also ensures that the lowering of the case doesn't cause the lookup in ACR to fail

- example previous server build -> https://github.com/bitwarden/server/actions/runs/25750372266
- example failure on the bw lite side -> https://github.com/bitwarden/self-host/actions/runs/25754000796