### PR TITLE
[BRE-1893] fix(azure-marketplace): certification failure

### DIFF
--- a/AzureMarketplace/marketplace-image.pkr.hcl
+++ b/AzureMarketplace/marketplace-image.pkr.hcl
@@ -27,6 +27,15 @@ variable "docker_packages" {
   default = "docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin"
 }
 
+# Pinned to a version above what apt noble-updates ships (currently 2.11.x).
+# Azure Marketplace cert check 200.3.3.4 fails for unspecified reasons against
+# the apt build; switch to a tarball install from upstream to remove the
+# Canonical packaging as a variable.
+variable "waagent_version" {
+  type    = string
+  default = "2.15.0.1"
+}
+
 variable "subscription_id" {
   type    = string
   default = "${env("AZURE_SUBSCRIPTION_ID")}"
@@ -137,6 +146,11 @@ build {
     destination = "/tmp/bitwarden-first-login.sh"
   }
 
+  provisioner "file" {
+    source      = "../CommonMarketplace/files/etc/systemd/system/disable-swap.service"
+    destination = "/tmp/disable-swap.service"
+  }
+
   # Move staged files to their final system locations
   provisioner "shell" {
     inline = [
@@ -148,8 +162,10 @@ build {
       "sudo mv /tmp/install-lite.sh /opt/bitwarden/install-lite.sh",
       "sudo mv /tmp/001_onboot /var/lib/cloud/scripts/per-instance/001_onboot",
       "sudo mv /tmp/bitwarden-first-login.sh /etc/profile.d/bitwarden-first-login.sh",
-      "sudo chown root:root /etc/update-motd.d/99-bitwarden-welcome /etc/ufw/applications.d/bitwarden /opt/bitwarden/setup-wizard.sh /opt/bitwarden/install-standard.sh /opt/bitwarden/install-lite.sh /var/lib/cloud/scripts/per-instance/001_onboot /etc/profile.d/bitwarden-first-login.sh",
-      "sudo chmod 644 /etc/ufw/applications.d/bitwarden /etc/profile.d/bitwarden-first-login.sh"
+      "sudo mv /tmp/disable-swap.service /etc/systemd/system/disable-swap.service",
+      "sudo chown root:root /etc/update-motd.d/99-bitwarden-welcome /etc/ufw/applications.d/bitwarden /opt/bitwarden/setup-wizard.sh /opt/bitwarden/install-standard.sh /opt/bitwarden/install-lite.sh /var/lib/cloud/scripts/per-instance/001_onboot /etc/profile.d/bitwarden-first-login.sh /etc/systemd/system/disable-swap.service",
+      "sudo chmod 644 /etc/ufw/applications.d/bitwarden /etc/profile.d/bitwarden-first-login.sh /etc/systemd/system/disable-swap.service",
+      "sudo systemctl enable disable-swap.service"
     ]
   }
 
@@ -177,7 +193,19 @@ build {
   provisioner "shell" {
     environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
     inline = [
-      "sudo apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install walinuxagent",
+      # Remove any walinuxagent shipped by Canonical so apt's version cannot
+      # override the upstream-source install on later upgrade.
+      "sudo apt-get -qqy purge walinuxagent || true",
+      "sudo apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install python3 python3-setuptools",
+      # Fetch the pinned upstream release and install via setup.py. The
+      # --register-service flag drops a systemd unit and a /etc/waagent.conf
+      # if missing. var.waagent_version is interpolated at template-compile
+      # time, not at shell-runtime.
+      "curl -fsSL -o /tmp/walinuxagent.tar.gz https://github.com/Azure/WALinuxAgent/archive/refs/tags/v${var.waagent_version}.tar.gz",
+      "sudo mkdir -p /opt/walinuxagent-src",
+      "sudo tar -xzf /tmp/walinuxagent.tar.gz -C /opt/walinuxagent-src --strip-components=1",
+      "cd /opt/walinuxagent-src && sudo python3 setup.py install --register-service",
+      "sudo rm -f /tmp/walinuxagent.tar.gz",
       "sudo systemctl enable walinuxagent",
       "waagent --version",
     ]
@@ -202,7 +230,9 @@ build {
     ]
   }
 
-  # Azure-specific cleanup
+  # Azure-specific cleanup. First pass at history deletion runs here so the
+  # image is in a clean state before deprovision; a second pass runs after
+  # deprovision below to catch anything deprovision recreates.
   provisioner "shell" {
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     environment_vars = [
@@ -211,15 +241,23 @@ build {
     ]
     inline = [
       "truncate -s 0 /var/log/waagent.log 2>/dev/null || true",
-      "find / -xdev -name '.bash_history' -type f -delete 2>/dev/null || true",
+      "find / -name '.bash_history' -type f -delete 2>/dev/null || true",
     ]
   }
 
-  # Azure generalization - must be the last provisioner
+  # Azure generalization - must be the last provisioner.
+  # Runs `sh` (dash) which does not write bash history, but waagent itself
+  # may shell out via bash during deprovision and recreate /root/.bash_history.
+  # After deprovision finishes, sweep again with HISTFILE=/dev/null so the
+  # captured disk has no .bash_history regardless of who recreated it.
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'"
+    environment_vars = [
+      "HISTFILE=/dev/null",
+      "HISTSIZE=0",
+    ]
     inline = [
-      "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+      "/usr/sbin/waagent -force -deprovision+user && find / -name '.bash_history' -type f -delete 2>/dev/null; export HISTSIZE=0 && sync"
     ]
   }
 

--- a/AzureMarketplace/scripts/99-img-check.sh
+++ b/AzureMarketplace/scripts/99-img-check.sh
@@ -57,16 +57,18 @@ else
   STATUS=2
 fi
 
-# Check Azure Linux Agent version (minimum 2.7.x required)
+# Check Azure Linux Agent version (minimum 2.13.x required by Azure Marketplace
+# cert 200.3.3.4; the apt-installed 2.11 from noble-updates is below this
+# floor and the packer build installs walinuxagent from upstream source).
 if hash waagent 2>/dev/null; then
   WAAGENT_VERSION=$(waagent --version 2>&1 | head -1 | grep -oP '(?<=WALinuxAgent-)\d+\.\d+' | head -1)
   WAAGENT_MAJOR=$(echo "${WAAGENT_VERSION}" | cut -d. -f1)
   WAAGENT_MINOR=$(echo "${WAAGENT_VERSION}" | cut -d. -f2)
-  if [[ "${WAAGENT_MAJOR}" -gt 2 ]] || ([[ "${WAAGENT_MAJOR}" -eq 2 ]] && [[ "${WAAGENT_MINOR}" -ge 7 ]]); then
+  if [[ "${WAAGENT_MAJOR}" -gt 2 ]] || ([[ "${WAAGENT_MAJOR}" -eq 2 ]] && [[ "${WAAGENT_MINOR}" -ge 13 ]]); then
     echo -en "\e[32m[PASS]\e[0m Azure Linux Agent version ${WAAGENT_VERSION} meets minimum requirement.\n"
     ((PASS++))
   else
-    echo -en "\e[41m[FAIL]\e[0m Azure Linux Agent version ${WAAGENT_VERSION} is below minimum supported version (2.7.x).\n"
+    echo -en "\e[41m[FAIL]\e[0m Azure Linux Agent version ${WAAGENT_VERSION} is below minimum supported version (2.13.x).\n"
     ((FAIL++))
     STATUS=2
   fi

--- a/CommonMarketplace/files/etc/systemd/system/disable-swap.service
+++ b/CommonMarketplace/files/etc/systemd/system/disable-swap.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Disable swap (Azure Marketplace 200.3.3.3 requirement)
+# Run after both the Azure linux agent and cloud-init's final stage so we
+# kill any swap they created on first boot before MPC's probe samples.
+After=walinuxagent.service cloud-final.service
+Wants=cloud-final.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/swapoff -a
+ExecStartPost=-/bin/rm -f /swap.img /swapfile
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/CommonMarketplace/scripts/90-cleanup.sh
+++ b/CommonMarketplace/scripts/90-cleanup.sh
@@ -44,8 +44,21 @@ EOF
 chmod 644 /etc/cloud/cloud.cfg.d/99-disable-swap.cfg
 
 # Configure SSH client alive interval (Azure requirement: 30-235 seconds).
-# Use a drop-in that sorts before /etc/ssh/sshd_config.d/50-cloud-init.conf so
-# this setting wins — sshd uses the first occurrence of each directive.
+# Write to BOTH the main sshd_config and a drop-in:
+#   - Main file: satisfies Azure's certification probe, which appears to do a
+#     literal grep of /etc/ssh/sshd_config and does not honor Include'd drop-ins.
+#   - Drop-in:   wins at sshd runtime against any later cloud-init drop-in
+#     because /etc/ssh/sshd_config.d/*.conf is sourced in lexical order and
+#     sshd uses the first occurrence of each directive.
+for directive in "ClientAliveInterval 120" "ClientAliveCountMax 3"; do
+  key="${directive%% *}"
+  if grep -qE "^[#[:space:]]*${key}\b" /etc/ssh/sshd_config; then
+    sed -i "s|^[#[:space:]]*${key}\b.*|${directive}|" /etc/ssh/sshd_config
+  else
+    echo "${directive}" >> /etc/ssh/sshd_config
+  fi
+done
+
 cat > /etc/ssh/sshd_config.d/10-bitwarden-marketplace.conf <<'EOF'
 ClientAliveInterval 120
 ClientAliveCountMax 3


### PR DESCRIPTION

## 🎟️ Tracking

[BRE-1893](https://bitwarden.atlassian.net/browse/BRE-1893)
## 📔 Objective

This is continuation of the efforts to resolve the MPC certification phase failures. This is preventing the VM Image to be published as a latest offering in the Azure Marketplace. 

**Verbosity for future reference:**

fix(azure-marketplace): write ClientAliveInterval to main sshd_config

Address Azure Marketplace certification check 200.3.3.1 ClientAliveInterval, which continues to fail despite the drop-in at /etc/ssh/sshd_config.d/10-bitwarden-marketplace.conf reporting the correct value via sshd -T. The probe appears to do a literal grep of /etc/ssh/sshd_config and not honor Include'd drop-ins.

* Replace the commented stock directives in /etc/ssh/sshd_config in place when present; append otherwise
* Keep the drop-in so the value still wins at sshd runtime against any later cloud-init drop-in

fix(azure-marketplace): add disable-swap systemd unit for cert 200.3.3.3

Address Azure Marketplace certification check 200.3.3.3 "No Swap Partition on OS Disk", which continues to fail despite build-time swapoff and the waagent.conf and cloud-init disables in 90-cleanup.sh. The probe samples a deployed VM after first boot, so a build-time disable is not sufficient if anything recreates swap during boot.

* Add disable-swap.service oneshot unit that runs after walinuxagent.service and cloud-final.service, runs swapoff -a, and removes /swap.img and /swapfile
* Wire the unit into the Azure packer build via file provisioner, install path, and systemctl enable

fix(azure-marketplace): install walinuxagent from upstream for cert 200.3.3.4

Address Azure Marketplace certification check 200.3.3.4 "Linux Agent Version", which fails against the apt-shipped walinuxagent 2.11 from noble-updates. Switch to an upstream-source install of a pinned version above the suspected MPC floor.

* Add waagent_version variable (default 2.15.0.1)
* Purge any apt-installed walinuxagent before source install to prevent dpkg conflicts on later upgrade
* Install python3 + python3-setuptools, fetch the GitHub release tarball, and run python3 setup.py install --register-service
* Bump 99-img-check.sh agent version floor from 2.7 to 2.13 so an accidental regression to apt install fails the build validator

fix(azure-marketplace): sweep .bash_history after deprovision for 200.5.1

Address Azure Marketplace certification check 200.5.1 "Bash History", which fails despite build-time deletion in 90-cleanup.sh and a pre-deprovision find. Likely culprit is that waagent shells out via bash during deprovision and recreates /root/.bash_history after our find runs.

* Drop -xdev from the pre-deprovision find so separate /home mounts are covered
* Run a second find for .bash_history inside the deprovision provisioner, chained after waagent -force -deprovision+user, so it runs immediately before image capture
* Add HISTFILE=/dev/null and HISTSIZE=0 to the deprovision provisioner env to keep waagent's bash subprocesses from writing history in the first place


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1893]: https://bitwarden.atlassian.net/browse/BRE-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ