### PR TITLE
[BRE-1893] fix(azure-marketplace): reset cloud-init state

### DIFF
--- a/AzureMarketplace/marketplace-image.pkr.hcl
+++ b/AzureMarketplace/marketplace-image.pkr.hcl
@@ -206,6 +206,9 @@ build {
       "sudo tar -xzf /tmp/walinuxagent.tar.gz -C /opt/walinuxagent-src --strip-components=1",
       "cd /opt/walinuxagent-src && sudo python3 setup.py install --register-service",
       "sudo rm -f /tmp/walinuxagent.tar.gz",
+      # Force systemd to re-read units after setup.py modifies walinuxagent.service.
+      # The version systemd has loaded is outdated" on first boot.
+      "sudo systemctl daemon-reload",
       "sudo systemctl enable walinuxagent",
       "waagent --version",
     ]

--- a/CommonMarketplace/scripts/90-cleanup.sh
+++ b/CommonMarketplace/scripts/90-cleanup.sh
@@ -78,5 +78,11 @@ done
 
 find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
-rm -rf /var/lib/cloud/instances/*
+# Reset cloud-init state for redeploy. `rm -rf /var/lib/cloud/instances/*` alone
+# leaves the /var/lib/cloud/instance symlink dangling, which causes cloud-init
+# to enter `degraded done` on the deployed VM's first boot
+if command -v cloud-init >/dev/null 2>&1; then
+  cloud-init clean --logs --machine-id
+fi
+rm -rf /var/lib/cloud/instance /var/lib/cloud/instances/* /var/lib/cloud/data/* /var/lib/cloud/sem/*
 rm -f /root/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys


### PR DESCRIPTION

## 🎟️ Tracking

[BRE-1893](https://bitwarden.atlassian.net/browse/BRE-1893)

## 📔 Objective

Addresses issue with `rm -rf /var/lib/cloud/instances/*` which left the `/var/lib/cloud/instance` symlink dangling after the packer build, so cloud-init could not re-initialize per-instance state on the deployed VM.
* Run `cloud-init clean --logs --machine-id` to reset cloud-init state the canonical way: handles the symlink, sem files, and machine-id together
* Keep `rm -rf` of /var/lib/cloud/{instance,instances/*,data/*,sem/*} as a defensive sweep in case the cloud-init version on the build host does not clean a particular path

Includes a minor change to AzureMarketplace/marketplace-image.pkr.hcl
* chore: Force systemd to re-read units


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1893]: https://bitwarden.atlassian.net/browse/BRE-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ