### PR TITLE
BRE-1893 fix(marketplace): preserve 001_onboot on cloud-init clean

### DIFF
--- a/CommonMarketplace/scripts/90-cleanup.sh
+++ b/CommonMarketplace/scripts/90-cleanup.sh
@@ -78,11 +78,18 @@ done
 
 find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
-# Reset cloud-init state for redeploy. `rm -rf /var/lib/cloud/instances/*` alone
-# leaves the /var/lib/cloud/instance symlink dangling, which causes cloud-init
-# to enter `degraded done` on the deployed VM's first boot
 if command -v cloud-init >/dev/null 2>&1; then
+  ONBOOT_SCRIPT=/var/lib/cloud/scripts/per-instance/001_onboot
+  if [ -f "$ONBOOT_SCRIPT" ]; then
+    cp -a "$ONBOOT_SCRIPT" /root/001_onboot.bak
+  fi
   cloud-init clean --logs --machine-id
+  if [ -f /root/001_onboot.bak ]; then
+    mkdir -p /var/lib/cloud/scripts/per-instance
+    mv /root/001_onboot.bak "$ONBOOT_SCRIPT"
+    chown root:root "$ONBOOT_SCRIPT"
+    chmod +x "$ONBOOT_SCRIPT"
+  fi
 fi
 rm -rf /var/lib/cloud/instance /var/lib/cloud/instances/* /var/lib/cloud/data/* /var/lib/cloud/sem/*
 rm -f /root/.ssh/authorized_keys /home/ubuntu/.ssh/authorized_keys


### PR DESCRIPTION

## 🎟️ Tracking

[BRE-1893](https://bitwarden.atlassian.net/browse/BRE-1893)

## 📔 Objective

cloud-init clean wipes all of /var/lib/cloud/, including the /var/lib/cloud/scripts/per-instance/001_onboot first-boot hook the deployed VM needs. The validator caught its absence after the cloud-init reset landed. Preserve the script across the clean.
* Copy 001_onboot to /root before cloud-init clean and move it back after, restoring root:root ownership and the executable bit
* Guard with `if [ -f ]` so the save/restore is a no-op on builds that do not ship the script

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1893]: https://bitwarden.atlassian.net/browse/BRE-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ