### PR TITLE
BRE-1893 fix(marketplace): guard against non-interactive shells

### DIFF
--- a/CommonMarketplace/files/opt/bitwarden/setup-wizard.sh
+++ b/CommonMarketplace/files/opt/bitwarden/setup-wizard.sh
@@ -4,6 +4,11 @@
 # Runs once on first interactive login to select the deployment edition.
 #
 
+# Don't run the interactive wizard in a non-interactive session
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  exit 0
+fi
+
 cat <<'EOF'
 
 ################################################################################
@@ -30,7 +35,7 @@ cat <<'EOF'
 EOF
 
 while true; do
-    read -rp "  Enter selection [1 or 2]: " SELECTION
+    read -rp "  Enter selection [1 or 2]: " SELECTION || exit 0
     case "$SELECTION" in
         1)
             EDITION="standard"


### PR DESCRIPTION


## 🎟️ Tracking

[BRE-1893](https://bitwarden.atlassian.net/browse/BRE-1893)

## 📔 Objective

The first-login setup wizard prompts for the deployment edition via a `read` loop. When a non-interactive session sources it, the prompt blocks the session, so the session's commands never run.
* Exit the wizard immediately when stdin or stdout is not a terminal, so non-interactive logins are never blocked
* Make the read EOF-safe (`|| exit 0`) so a closed stdin cannot spin the selection loop

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1893]: https://bitwarden.atlassian.net/browse/BRE-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ