### PR TITLE
[BRE-2049] Add tag existence check to prevent overwriting images

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -279,6 +279,51 @@ jobs:
           echo "- Server: ${SERVER_REGISTRY}/*:${SERVER_TAG}" >> $GITHUB_STEP_SUMMARY
           echo "- Web: ${WEB_IMAGE}:${WEB_TAG}" >> $GITHUB_STEP_SUMMARY
 
+      - name: Check if image tag already exists
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          GHCR_REGISTRY: ghcr.io/bitwarden
+          ACR_REGISTRY: bitwardenprod.azurecr.io
+        run: |
+          # Only check version tags (numeric), skip dev/branch tags
+          if [[ "$IMAGE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Checking if version tag ${IMAGE_TAG} already exists..."
+
+            # Check GHCR
+            output=$(skopeo inspect "docker://${GHCR_REGISTRY}/lite:${IMAGE_TAG}" 2>&1)
+            status=$?
+            if [[ $status -eq 0 ]]; then
+              echo "::error::❌ Tag ${IMAGE_TAG} already exists at ${GHCR_REGISTRY}/lite:${IMAGE_TAG}"
+              echo "::error::Refusing to overwrite existing production image."
+              echo "::error::If you need to rebuild this version, delete the existing tag first."
+              exit 1
+            elif echo "$output" | grep -qiE 'manifest unknown|not found|name unknown'; then
+              echo "✅ GHCR tag ${IMAGE_TAG} is available"
+            else
+              echo "::error::Could not verify GHCR tag existence (skopeo failed): $output"
+              exit 1
+            fi
+
+            # Check ACR
+            output=$(skopeo inspect "docker://${ACR_REGISTRY}/lite:${IMAGE_TAG}" 2>&1)
+            status=$?
+            if [[ $status -eq 0 ]]; then
+              echo "::error::❌ Tag ${IMAGE_TAG} already exists at ${ACR_REGISTRY}/lite:${IMAGE_TAG}"
+              echo "::error::Refusing to overwrite existing production image."
+              echo "::error::If you need to rebuild this version, delete the existing tag first."
+              exit 1
+            elif echo "$output" | grep -qiE 'manifest unknown|not found|name unknown'; then
+              echo "✅ ACR tag ${IMAGE_TAG} is available"
+            else
+              echo "::error::Could not verify ACR tag existence (skopeo failed): $output"
+              exit 1
+            fi
+
+            echo "✅ Tag ${IMAGE_TAG} is available on both registries"
+          else
+            echo "Skipping tag check for non-version tag: ${IMAGE_TAG}"
+          fi
+
       - name: Build and push Docker image
         id: build-docker
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2049

## 📔 Objective

Prevents `build-bitwarden-lite` from overwriting existing production container image tags.

Changes:
- Add pre-push check using skopeo inspect
- Only validates version tags (X.Y.Z format)
- Skips check for dev/branch tags to allow rebuilds
- Fails with clear error message if tag already exists

This provides defense-in-depth protection against tag overwrites from any workflow source, regardless of how it was triggered.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
