### PR TITLE
[BRE-1533] Support Bitwarden Lite dispatch from server and clients

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -29,6 +29,14 @@ on:
         description: "Override tag for the Bitwarden Lite image (cannot be 'rc', 'hotfix-rc', or 'dev')"
         type: string
         required: false
+      server_tag:
+        description: "Exact upstream server image tag to pull (skips derivation from server_branch)"
+        type: string
+        required: false
+      web_tag:
+        description: "Exact upstream web image tag to pull (skips derivation from web_branch)"
+        type: string
+        required: false
       use_latest_core_version:
         description: "Use the latest core version from version.json instead of branch"
         type: boolean
@@ -53,6 +61,14 @@ on:
         default: main
       override_tag:
         description: "Override tag for the Bitwarden Lite image (cannot be 'rc', 'hotfix-rc', or 'dev')"
+        type: string
+        required: false
+      server_tag:
+        description: "Exact upstream server image tag to pull (skips derivation from server_branch)"
+        type: string
+        required: false
+      web_tag:
+        description: "Exact upstream web image tag to pull (skips derivation from web_branch)"
         type: string
         required: false
       use_latest_core_version:
@@ -103,14 +119,14 @@ jobs:
     permissions:
       contents: read
     outputs:
-      server_ref: ${{ steps.resolve.outputs.server_ref }}
-      web_ref: ${{ steps.resolve.outputs.web_ref }}
-      image_tag: ${{ steps.resolve.outputs.image_tag }}
-      server_tag: ${{ steps.resolve.outputs.server_tag }}
-      web_tag: ${{ steps.resolve.outputs.web_tag }}
-      web_image: ${{ steps.resolve.outputs.web_image }}
-      server_registry: ${{ steps.resolve.outputs.server_registry }}
-      push_to_ghcr: ${{ steps.resolve.outputs.push_to_ghcr }}
+      server_ref: ${{ steps.refs.outputs.server_ref }}
+      web_ref: ${{ steps.refs.outputs.web_ref }}
+      image_tag: ${{ steps.finalize.outputs.image_tag }}
+      server_tag: ${{ steps.finalize.outputs.server_tag }}
+      web_tag: ${{ steps.finalize.outputs.web_tag }}
+      web_image: ${{ steps.finalize.outputs.web_image }}
+      server_registry: ${{ steps.finalize.outputs.server_registry }}
+      push_to_ghcr: ${{ steps.finalize.outputs.push_to_ghcr }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -118,8 +134,8 @@ jobs:
           ref: ${{ inputs.self_host_repo_ref || github.event.client_payload.self_host_repo_ref || github.ref }}
           persist-credentials: false
 
-      - name: Resolve build variables
-        id: resolve
+      - name: Validate inputs and resolve refs
+        id: refs
         env:
           SERVER_BRANCH_INPUT: ${{ inputs.server_branch || github.event.client_payload.server_branch }}
           WEB_BRANCH_INPUT: ${{ inputs.web_branch || github.event.client_payload.web_branch }}
@@ -166,30 +182,60 @@ jobs:
             WEB_REF="refs/heads/${WEB_BRANCH#refs/heads/}"
           fi
 
-          # Upstream server image tag (what to pull from server's registry)
-          if [[ $SERVER_REF =~ ^refs/tags/v(.+)$ ]]; then
-            SERVER_TAG="${BASH_REMATCH[1]}"
+          # Extract version from web's `refs/tags/web-v<version>` format so the
+          # sanitize-image-tag action sees just the version string.
+          if [[ "$WEB_REF" =~ ^refs/tags/web-v(.+)$ ]]; then
+            WEB_REF_FOR_TAG="${BASH_REMATCH[1]}"
           else
-            SERVER_TAG=$(echo "${SERVER_REF#refs/heads/}" | sed 's|/|-|g' | cut -c1-128)
-            [[ "$SERVER_TAG" == "main" ]] && SERVER_TAG=dev
+            WEB_REF_FOR_TAG="$WEB_REF"
           fi
 
-          # Upstream web image (always GHCR; release uses `web`, branch builds use `web-dev`)
-          if [[ $WEB_REF =~ ^refs/tags/web-v(.+)$ ]]; then
-            WEB_TAG="${BASH_REMATCH[1]}"
+          echo "server_ref=$SERVER_REF" >> "$GITHUB_OUTPUT"
+          echo "web_ref=$WEB_REF" >> "$GITHUB_OUTPUT"
+          echo "web_ref_for_tag=$WEB_REF_FOR_TAG" >> "$GITHUB_OUTPUT"
+          echo "server_branch=$SERVER_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "web_branch=$WEB_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "override_tag=$OVERRIDE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Sanitize server tag
+        id: sanitize-server
+        if: (inputs.server_tag || github.event.client_payload.server_tag) == ''
+        uses: bitwarden/gh-actions/sanitize-image-tag@main
+        with:
+          ref: ${{ steps.refs.outputs.server_ref }}
+
+      - name: Sanitize web tag
+        id: sanitize-web
+        if: (inputs.web_tag || github.event.client_payload.web_tag) == ''
+        uses: bitwarden/gh-actions/sanitize-image-tag@main
+        with:
+          ref: ${{ steps.refs.outputs.web_ref_for_tag }}
+
+      - name: Resolve final values
+        id: finalize
+        env:
+          SERVER_REF: ${{ steps.refs.outputs.server_ref }}
+          WEB_REF: ${{ steps.refs.outputs.web_ref }}
+          SERVER_BRANCH: ${{ steps.refs.outputs.server_branch }}
+          WEB_BRANCH: ${{ steps.refs.outputs.web_branch }}
+          OVERRIDE_TAG: ${{ steps.refs.outputs.override_tag }}
+          SERVER_TAG_OVERRIDE: ${{ inputs.server_tag || github.event.client_payload.server_tag }}
+          WEB_TAG_OVERRIDE: ${{ inputs.web_tag || github.event.client_payload.web_tag }}
+          SERVER_TAG_FROM_ACTION: ${{ steps.sanitize-server.outputs.tag }}
+          WEB_TAG_FROM_ACTION: ${{ steps.sanitize-web.outputs.tag }}
+        run: |
+          SERVER_TAG="${SERVER_TAG_OVERRIDE:-$SERVER_TAG_FROM_ACTION}"
+          WEB_TAG="${WEB_TAG_OVERRIDE:-$WEB_TAG_FROM_ACTION}"
+
+          # Web image: release uses `web`, branch builds use `web-dev`
+          if [[ "$WEB_REF" =~ ^refs/tags/web-v ]]; then
             WEB_IMAGE="ghcr.io/bitwarden/web"
           else
-            WEB_TAG=$(echo "${WEB_REF#refs/heads/}" | \
-              tr '[:upper:]' '[:lower:]' | \
-              sed -E 's/[^a-z0-9._-]+/-/g; s/-+/-/g; s/^-+|-+$//g' | \
-              cut -c1-128 | \
-              sed -E 's/[.-]$//')
-            [[ "$WEB_TAG" == "main" ]] && WEB_TAG=dev
             WEB_IMAGE="ghcr.io/bitwarden/web-dev"
           fi
 
           # Bitwarden Lite image tag: version > override > branch agreement
-          if [[ $SERVER_REF =~ ^refs/tags/v(.+)$ ]]; then
+          if [[ "$SERVER_REF" =~ ^refs/tags/v(.+)$ ]]; then
             IMAGE_TAG="${BASH_REMATCH[1]}"
           elif [[ -n "$OVERRIDE_TAG" ]]; then
             IMAGE_TAG="$OVERRIDE_TAG"
@@ -222,8 +268,6 @@ jobs:
             PUSH_TO_GHCR=false
           fi
 
-          echo "server_ref=$SERVER_REF" >> "$GITHUB_OUTPUT"
-          echo "web_ref=$WEB_REF" >> "$GITHUB_OUTPUT"
           echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           echo "server_tag=$SERVER_TAG" >> "$GITHUB_OUTPUT"
           echo "web_tag=$WEB_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -227,11 +227,14 @@ jobs:
           SERVER_TAG="${SERVER_TAG_OVERRIDE:-$SERVER_TAG_FROM_ACTION}"
           WEB_TAG="${WEB_TAG_OVERRIDE:-$WEB_TAG_FROM_ACTION}"
 
-          # Web image: release uses `web`, branch builds use `web-dev`
+          # Web image: release goes to GHCR `web`; reserved tags (dev/rc/hotfix-rc-web) go to
+          # GHCR `web-dev`; everything else (feature branches) is ACR-only at `web`.
           if [[ "$WEB_REF" =~ ^refs/tags/web-v ]]; then
             WEB_IMAGE="ghcr.io/bitwarden/web"
-          else
+          elif [[ "$WEB_TAG" == "dev" || "$WEB_TAG" == "rc" || "$WEB_TAG" == "hotfix-rc-web" ]]; then
             WEB_IMAGE="ghcr.io/bitwarden/web-dev"
+          else
+            WEB_IMAGE="bitwardenprod.azurecr.io/web"
           fi
 
           # Bitwarden Lite image tag: version > override > branch agreement

--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -25,6 +25,10 @@ on:
         description: "Web client branch name (examples: 'main', 'rc', 'feature/sm')"
         type: string
         default: main
+      override_tag:
+        description: "Override tag for the Bitwarden Lite image (cannot be 'rc', 'hotfix-rc', or 'dev')"
+        type: string
+        required: false
       use_latest_core_version:
         description: "Use the latest core version from version.json instead of branch"
         type: boolean
@@ -47,6 +51,10 @@ on:
         description: "Web client branch name (examples: 'main', 'rc', 'feature/sm')"
         type: string
         default: main
+      override_tag:
+        description: "Override tag for the Bitwarden Lite image (cannot be 'rc', 'hotfix-rc', or 'dev')"
+        type: string
+        required: false
       use_latest_core_version:
         description: "Use the latest core version from version.json instead of branch"
         type: boolean
@@ -95,9 +103,14 @@ jobs:
     permissions:
       contents: read
     outputs:
-      server_ref: ${{ steps.set-server-variables.outputs.server_ref }}
-      web_ref: ${{ steps.set-web-variables.outputs.web_ref }}
-      push_to_ghcr: ${{ steps.set-server-variables.outputs.push_to_ghcr }}
+      server_ref: ${{ steps.resolve.outputs.server_ref }}
+      web_ref: ${{ steps.resolve.outputs.web_ref }}
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
+      server_tag: ${{ steps.resolve.outputs.server_tag }}
+      web_tag: ${{ steps.resolve.outputs.web_tag }}
+      web_image: ${{ steps.resolve.outputs.web_image }}
+      server_registry: ${{ steps.resolve.outputs.server_registry }}
+      push_to_ghcr: ${{ steps.resolve.outputs.push_to_ghcr }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -105,48 +118,123 @@ jobs:
           ref: ${{ inputs.self_host_repo_ref || github.event.client_payload.self_host_repo_ref || github.ref }}
           persist-credentials: false
 
-      - name: Set Server variables
-        id: set-server-variables
+      - name: Resolve build variables
+        id: resolve
         env:
-          SERVER_BRANCH: ${{ inputs.server_branch || github.event.client_payload.server_branch }}
+          SERVER_BRANCH_INPUT: ${{ inputs.server_branch || github.event.client_payload.server_branch }}
+          WEB_BRANCH_INPUT: ${{ inputs.web_branch || github.event.client_payload.web_branch }}
+          OVERRIDE_TAG_INPUT: ${{ inputs.override_tag || github.event.client_payload.override_tag }}
           USE_LATEST_CORE_VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.use_latest_core_version || inputs.use_latest_core_version }}
+          USE_LATEST_WEB_VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.use_latest_web_version || inputs.use_latest_web_version }}
         run: |
+          SERVER_BRANCH="$SERVER_BRANCH_INPUT"
+          WEB_BRANCH="$WEB_BRANCH_INPUT"
+          OVERRIDE_TAG="$OVERRIDE_TAG_INPUT"
+
+          # Reject overrides that collide with reserved tags
+          case "$OVERRIDE_TAG" in
+            rc|hotfix-rc|dev)
+              echo "ERROR: override_tag cannot be a reserved value (rc, hotfix-rc, dev)"
+              exit 1
+              ;;
+          esac
+
+          # Branch normalization: both empty -> main; one empty -> mirror the other
+          if [[ -z "$SERVER_BRANCH" && -z "$WEB_BRANCH" ]]; then
+            SERVER_BRANCH=main
+            WEB_BRANCH=main
+          elif [[ -z "$SERVER_BRANCH" ]]; then
+            SERVER_BRANCH="$WEB_BRANCH"
+          elif [[ -z "$WEB_BRANCH" ]]; then
+            WEB_BRANCH="$SERVER_BRANCH"
+          fi
+
+          # Resolve refs (version flags take precedence over branch)
           if [[ "$USE_LATEST_CORE_VERSION" == "true" ]]; then
             CORE_VERSION=$(jq -r '.versions.coreVersion' version.json)
             echo "Server version from version.json: $CORE_VERSION"
             SERVER_REF="refs/tags/v$CORE_VERSION"
-          elif [[ -z "${SERVER_BRANCH}" ]]; then
-            SERVER_REF="refs/heads/main"
           else
             SERVER_REF="refs/heads/${SERVER_BRANCH#refs/heads/}"
           fi
 
-          echo "server_ref=$SERVER_REF" >> "$GITHUB_OUTPUT"
-
-          # Always push to ACR. Additionally push to GHCR for rc, hotfix-rc, and version tags.
-          BRANCH_NAME="${SERVER_REF#refs/heads/}"
-          if [[ "$SERVER_REF" =~ ^refs/tags/ ]] || [[ "$BRANCH_NAME" == "rc" ]] || [[ "$BRANCH_NAME" == "hotfix-rc" ]]; then
-            echo "push_to_ghcr=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "push_to_ghcr=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set Web variables
-        id: set-web-variables
-        env:
-          WEB_BRANCH: ${{ inputs.web_branch || github.event.client_payload.web_branch }}
-          USE_LATEST_WEB_VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.use_latest_web_version || inputs.use_latest_web_version }}
-        run: |
           if [[ "$USE_LATEST_WEB_VERSION" == "true" ]]; then
-            # Extract webVersion from version.json
             WEB_VERSION=$(jq -r '.versions.webVersion' version.json)
             echo "Web version from version.json: $WEB_VERSION"
-            echo "web_ref=refs/tags/web-v$WEB_VERSION" >> "$GITHUB_OUTPUT"
-          elif [[ -z "${WEB_BRANCH}" ]]; then
-            echo "web_ref=refs/heads/main" >> "$GITHUB_OUTPUT"
+            WEB_REF="refs/tags/web-v$WEB_VERSION"
           else
-            echo "web_ref=refs/heads/${WEB_BRANCH#refs/heads/}" >> "$GITHUB_OUTPUT"
+            WEB_REF="refs/heads/${WEB_BRANCH#refs/heads/}"
           fi
+
+          # Upstream server image tag (what to pull from server's registry)
+          if [[ $SERVER_REF =~ ^refs/tags/v(.+)$ ]]; then
+            SERVER_TAG="${BASH_REMATCH[1]}"
+          else
+            SERVER_TAG=$(echo "${SERVER_REF#refs/heads/}" | sed 's|/|-|g' | cut -c1-128)
+            [[ "$SERVER_TAG" == "main" ]] && SERVER_TAG=dev
+          fi
+
+          # Upstream web image (always GHCR; release uses `web`, branch builds use `web-dev`)
+          if [[ $WEB_REF =~ ^refs/tags/web-v(.+)$ ]]; then
+            WEB_TAG="${BASH_REMATCH[1]}"
+            WEB_IMAGE="ghcr.io/bitwarden/web"
+          else
+            WEB_TAG=$(echo "${WEB_REF#refs/heads/}" | \
+              tr '[:upper:]' '[:lower:]' | \
+              sed -E 's/[^a-z0-9._-]+/-/g; s/-+/-/g; s/^-+|-+$//g' | \
+              cut -c1-128 | \
+              sed -E 's/[.-]$//')
+            [[ "$WEB_TAG" == "main" ]] && WEB_TAG=dev
+            WEB_IMAGE="ghcr.io/bitwarden/web-dev"
+          fi
+
+          # Bitwarden Lite image tag: version > override > branch agreement
+          if [[ $SERVER_REF =~ ^refs/tags/v(.+)$ ]]; then
+            IMAGE_TAG="${BASH_REMATCH[1]}"
+          elif [[ -n "$OVERRIDE_TAG" ]]; then
+            IMAGE_TAG="$OVERRIDE_TAG"
+          elif [[ "$SERVER_BRANCH" == "$WEB_BRANCH" ]]; then
+            case "$SERVER_BRANCH" in
+              main) IMAGE_TAG=dev ;;
+              rc) IMAGE_TAG=rc ;;
+              hotfix-rc) IMAGE_TAG=hotfix-rc ;;
+              *)
+                echo "ERROR: override_tag must be specified when server_branch=$SERVER_BRANCH and web_branch=$WEB_BRANCH"
+                exit 1
+                ;;
+            esac
+          else
+            echo "ERROR: override_tag must be specified when server_branch=$SERVER_BRANCH and web_branch=$WEB_BRANCH"
+            exit 1
+          fi
+
+          # Upstream server registry: GHCR for rc/hotfix-rc/version, ACR otherwise
+          if [[ "$SERVER_TAG" == "rc" || "$SERVER_TAG" == "hotfix-rc" ]] || [[ "$SERVER_REF" =~ ^refs/tags/v ]]; then
+            SERVER_REGISTRY="ghcr.io/bitwarden"
+          else
+            SERVER_REGISTRY="bitwardenprod.azurecr.io"
+          fi
+
+          # Always push Bitwarden Lite to ACR; also push to GHCR for reserved tags and version tags
+          if [[ "$IMAGE_TAG" == "rc" || "$IMAGE_TAG" == "hotfix-rc" || "$IMAGE_TAG" == "dev" ]] || [[ "$SERVER_REF" =~ ^refs/tags/v ]]; then
+            PUSH_TO_GHCR=true
+          else
+            PUSH_TO_GHCR=false
+          fi
+
+          echo "server_ref=$SERVER_REF" >> "$GITHUB_OUTPUT"
+          echo "web_ref=$WEB_REF" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "server_tag=$SERVER_TAG" >> "$GITHUB_OUTPUT"
+          echo "web_tag=$WEB_TAG" >> "$GITHUB_OUTPUT"
+          echo "web_image=$WEB_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "server_registry=$SERVER_REGISTRY" >> "$GITHUB_OUTPUT"
+          echo "push_to_ghcr=$PUSH_TO_GHCR" >> "$GITHUB_OUTPUT"
+
+          echo "Lite tag: $IMAGE_TAG"
+          echo "Server: $SERVER_REGISTRY/*:$SERVER_TAG"
+          echo "Web: $WEB_IMAGE:$WEB_TAG"
+          echo "Push to GHCR: $PUSH_TO_GHCR"
 
   build-docker:
     name: Build Docker image
@@ -202,62 +290,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate Docker image tag
-        id: tag
-        env:
-          SERVER_REF: ${{ needs.setup.outputs.server_ref }}
-        run: |
-          if [[ $SERVER_REF =~ ^refs/tags/v(.+)$ ]]; then
-              IMAGE_TAG="${BASH_REMATCH[1]}"
-              SERVER_TAG="${BASH_REMATCH[1]}"
-          else
-              IMAGE_TAG=$(echo "${SERVER_REF#refs/heads/}" | \
-              tr '[:upper:]' '[:lower:]' | \
-              sed -E 's/[^a-z0-9._-]+/-/g; s/-+/-/g; s/^-+|-+$//g' | \
-              cut -c1-128 | \
-              sed -E 's/[.-]$//')
-              SERVER_TAG=$(echo "${SERVER_REF#refs/heads/}" | sed 's|/|-|g' | cut -c1-128)
-          fi
-
-          if [[ "$IMAGE_TAG" == "main" ]]; then
-            IMAGE_TAG=dev
-            SERVER_TAG=dev
-          fi
-
-          if [[ -z "$IMAGE_TAG" ]]; then
-            echo "ERROR: Failed to generate valid IMAGE_TAG from SERVER_REF: $SERVER_REF"
-            exit 1
-          fi
-
-          echo "Using lite tag $IMAGE_TAG, server tag $SERVER_TAG"
-          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "server_tag=${SERVER_TAG}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate web image tag
-        id: web-tag
-        env:
-          WEB_REF: ${{ needs.setup.outputs.web_ref }}
-        run: |
-          if [[ $WEB_REF =~ ^refs/tags/web-v(.+)$ ]]; then
-            WEB_TAG="${BASH_REMATCH[1]}"
-            WEB_IMAGE="ghcr.io/bitwarden/web"
-          else
-            WEB_TAG=$(echo "${WEB_REF#refs/heads/}" | \
-              tr '[:upper:]' '[:lower:]' | \
-              sed -E 's/[^a-z0-9._-]+/-/g; s/-+/-/g; s/^-+|-+$//g' | \
-              cut -c1-128 | \
-              sed -E 's/[.-]$//')
-            [[ "$WEB_TAG" == "main" ]] && WEB_TAG=dev
-            WEB_IMAGE="ghcr.io/bitwarden/web-dev"
-          fi
-          echo "web_tag=${WEB_TAG}" >> "$GITHUB_OUTPUT"
-          echo "web_image=${WEB_IMAGE}" >> "$GITHUB_OUTPUT"
-
       - name: Determine image tags
         id: image-ref
         env:
           PUSH_TO_GHCR: ${{ needs.setup.outputs.push_to_ghcr }}
-          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          IMAGE_TAG: ${{ needs.setup.outputs.image_tag }}
         run: |
           TAGS="bitwardenprod.azurecr.io/lite:${IMAGE_TAG}"
           if [[ "$PUSH_TO_GHCR" == "true" ]]; then
@@ -269,10 +306,10 @@ jobs:
       - name: Log build configuration
         env:
           IMAGE_TAGS: ${{ steps.image-ref.outputs.tags }}
-          SERVER_REGISTRY: ${{ needs.setup.outputs.push_to_ghcr == 'true' && 'ghcr.io/bitwarden' || 'bitwardenprod.azurecr.io' }}
-          SERVER_TAG: ${{ steps.tag.outputs.server_tag }}
-          WEB_IMAGE: ${{ steps.web-tag.outputs.web_image }}
-          WEB_TAG: ${{ steps.web-tag.outputs.web_tag }}
+          SERVER_REGISTRY: ${{ needs.setup.outputs.server_registry }}
+          SERVER_TAG: ${{ needs.setup.outputs.server_tag }}
+          WEB_IMAGE: ${{ needs.setup.outputs.web_image }}
+          WEB_TAG: ${{ needs.setup.outputs.web_tag }}
         run: |
           echo "### Build Configuration" >> $GITHUB_STEP_SUMMARY
           echo "- Lite: ${IMAGE_TAGS}" >> $GITHUB_STEP_SUMMARY
@@ -292,10 +329,10 @@ jobs:
           push: ${{ steps.check-secrets.outputs.has_secrets == 'true' }}
           tags: ${{ steps.image-ref.outputs.tags }}
           build-args: |
-            SERVER_TAG=${{ steps.tag.outputs.server_tag }}
-            SERVER_REGISTRY=${{ needs.setup.outputs.push_to_ghcr == 'true' && 'ghcr.io/bitwarden' || 'bitwardenprod.azurecr.io' }}
-            WEB_IMAGE=${{ steps.web-tag.outputs.web_image }}
-            WEB_TAG=${{ steps.web-tag.outputs.web_tag }}
+            SERVER_TAG=${{ needs.setup.outputs.server_tag }}
+            SERVER_REGISTRY=${{ needs.setup.outputs.server_registry }}
+            WEB_IMAGE=${{ needs.setup.outputs.web_image }}
+            WEB_TAG=${{ needs.setup.outputs.web_tag }}
 
       - name: Install Cosign
         if: steps.check-secrets.outputs.has_secrets == 'true'
@@ -307,7 +344,7 @@ jobs:
           DIGEST: ${{ steps.build-docker.outputs.digest }}
           PUSH_TO_GHCR: ${{ needs.setup.outputs.push_to_ghcr }}
           ACR_IMAGE: ${{ steps.image-ref.outputs.acr_image }}
-          GHCR_IMAGE: ghcr.io/bitwarden/lite:${{ steps.tag.outputs.image_tag }}
+          GHCR_IMAGE: ghcr.io/bitwarden/lite:${{ needs.setup.outputs.image_tag }}
         run: |
           cosign sign --yes "${ACR_IMAGE}@${DIGEST}"
           if [[ "$PUSH_TO_GHCR" == "true" ]]; then


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1533](https://bitwarden.atlassian.net/browse/BRE-1533)

## 📔 Objective

Enable the `server` and `clients` repositories to dispatch Bitwarden Lite builds for their own branch/PR builds, tagged with a `server-` or `web-` prefix, and routed to our ACR so they're covered by image retention.

## Changes

- New workflow inputs: `override_tag`, `server_tag`, `web_tag` (all optional).
- Image tag resolution order: version tag > `override_tag` > branch agreement (`main` → `dev`, `rc` → `rc`, `hotfix-rc` → `hotfix-rc`). Reserved values (`rc`, `hotfix-rc`, `dev`) are rejected as `override_tag`.
- Branch normalization: when both branches are empty, default to `main`; when one is empty, mirror the other.
- New `server_registry` output, decoupled from `push_to_ghcr`, so the upstream-pull registry doesn't have to match the push target.
- Push to GHCR for `rc` / `hotfix-rc` / `dev` and version tags; override-tagged builds stay ACR-only.
- Centralized tag sanitization via `bitwarden/gh-actions/sanitize-image-tag@main`.

## Behavior change

`main` builds now push to GHCR in addition to ACR (previously ACR-only). All four reserved tags (`dev`, `rc`, `hotfix-rc`, version tags) are now treated uniformly.

[BRE-1533]: https://bitwarden.atlassian.net/browse/BRE-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ