### PR TITLE
[PM-41091] Add workflow to automatically label a PR by change type

### DIFF
--- a/.github/label-pr.json
+++ b/.github/label-pr.json
@@ -1,0 +1,21 @@
+{
+  "title_patterns": {
+    "t:feature": ["feat", "feature", "tool"],
+    "t:bugfix": ["fix", "bug", "bugfix"],
+    "t:tech-debt": ["refactor", "chore", "cleanup", "revert", "debt", "test", "perf"],
+    "t:docs": ["docs"],
+    "t:ci": ["ci", "build", "chore(ci)"],
+    "t:deps": ["deps", "[deps]"],
+    "t:breaking-change": ["breaking", "breaking-change"],
+    "t:misc": ["misc"],
+    "t:llm": ["llm"]
+  },
+  "path_patterns": {
+    "t:feature": [],
+    "t:tech-debt": [],
+    "t:ci": [".github/"],
+    "t:docs": ["README.md", "CONTRIBUTING.md", "SECURITY.md"],
+    "t:deps": [],
+    "t:llm": [".claude/", "CLAUDE.md"]
+  }
+}

--- a/.github/workflows/auto-label-pr-sdlc.yml
+++ b/.github/workflows/auto-label-pr-sdlc.yml
@@ -1,0 +1,29 @@
+name: Label PR
+run-name: Label PR #${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Label PR
+        uses: bitwarden/gh-actions/auto-label-pr-sdlc@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          pr-labels: ${{ toJSON(github.event.pull_request.labels) }}
+          mode: add
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41091

Depends on https://github.com/bitwarden/gh-actions/pull/829
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds a workflow that gets triggered when a PR is opened, synchronized or re-opened. It calls a composite action living in bitwarden/gh-actions and passes the PR number and any existing labels to it. The composite action looks for a configuration file (`.github/label-pr.json`) and tries to match the change type via PR title and/or changed files.

It then applies one of the labels `t:*` to the PR.

These change type labels are then used to create categories for the Github release notes.