### PR TITLE
[BRE-2116] Add allow-unsafe-pr-checkout to build-bitwarden-lite

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -148,6 +148,7 @@ jobs:
         with:
           ref: ${{ inputs.self_host_repo_ref || github.event.client_payload.self_host_repo_ref || github.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Validate inputs and resolve refs
         id: refs
@@ -314,6 +315,7 @@ jobs:
         with:
           ref: ${{ inputs.self_host_repo_ref || github.event.client_payload.self_host_repo_ref || github.ref }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Check secrets
         id: check-secrets


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2116

## 📔 Objective

Adds `allow-unsafe-pr-checkout: true` to the 2 fork-checkout steps in `build-bitwarden-lite.yml` (already on checkout `v7.0.1`).

`build-bitwarden-lite.yml` runs via `build-bitwarden-lite-workflow-target.yml` (`pull_request_target`), which passes the fork `head.sha` in as `self_host_repo_ref` for the setup and build-docker jobs to check out. checkout v7 refuses that fork checkout by default; without this flag the fork-PR build path is broken.

Regression-prevention only — this preserves existing behavior and does NOT remediate the underlying pwn-request exposure (fork code running in a privileged context). Remediation is scoped in the follow-up spike.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
