### PR TITLE
[BRE-2166] Add metadata to Bitwarden Lite container image

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -430,17 +430,10 @@ jobs:
             echo "Skipping tag check for non-version tag: ${IMAGE_TAG}"
           fi
 
-      # `github.sha` points at the triggering commit, which is NOT the built commit when
-      # `self_host_repo_ref` is supplied (dispatch/workflow_call). Read the actual checked-out
-      # HEAD so org.opencontainers.image.revision always names the commit that produced the image.
       - name: Resolve built revision
         id: revision
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      # metadata-action builds its `labels` and `annotations` outputs independently, each merging
-      # only its own input over the same generated defaults. Supplying just `labels` leaves the
-      # annotations at the raw defaults (title=self-host, version=<branch>, revision=github.sha).
-      # Build the custom set once here and feed it to both inputs so they cannot drift.
       - name: Build custom image metadata
         id: custom-meta
         env:
@@ -472,17 +465,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         env:
-          # Annotate the manifest list too, not just per-arch manifests, so the metadata is
-          # visible on the multi-arch index that clients actually resolve first.
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
-          # Tags come from the `image-ref` step, which encodes this repo's ACR/GHCR promotion
-          # rules. The `tags` output of this action is intentionally unused.
           images: |
             bitwardenprod.azurecr.io/lite
             ghcr.io/bitwarden/lite
-          # `version` and `revision` are overridden because this action derives both from the
-          # git ref, which does not match our resolved image tag or the checked-out commit.
           labels: ${{ steps.custom-meta.outputs.items }}
           annotations: ${{ steps.custom-meta.outputs.items }}
 

--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -252,11 +252,13 @@ jobs:
             WEB_IMAGE="bitwardenprod.azurecr.io/web"
           fi
 
-          # Bitwarden Lite image tag: version > override > branch agreement
-          if [[ "$SERVER_REF" =~ ^refs/tags/v(.+)$ ]]; then
-            IMAGE_TAG="${BASH_REMATCH[1]}"
-          elif [[ -n "$OVERRIDE_TAG" ]]; then
+          # Bitwarden Lite image tag: override > version > branch agreement.
+          # `use_latest_core_version` selects which upstream server code to consume; it does not
+          # name the output image. A non-blank override_tag is always honored.
+          if [[ -n "$OVERRIDE_TAG" ]]; then
             IMAGE_TAG="$OVERRIDE_TAG"
+          elif [[ "$SERVER_REF" =~ ^refs/tags/v(.+)$ ]]; then
+            IMAGE_TAG="${BASH_REMATCH[1]}"
           elif [[ "$SERVER_BRANCH" == "$WEB_BRANCH" ]]; then
             case "$SERVER_BRANCH" in
               main) IMAGE_TAG=dev ;;
@@ -279,8 +281,13 @@ jobs:
             SERVER_REGISTRY="bitwardenprod.azurecr.io"
           fi
 
-          # Always push Bitwarden Lite to ACR; also push to GHCR for reserved tags and version tags
-          if [[ "$IMAGE_TAG" == "rc" || "$IMAGE_TAG" == "hotfix-rc" || "$IMAGE_TAG" == "dev" ]] || [[ "$SERVER_REF" =~ ^refs/tags/v ]]; then
+          # Always push Bitwarden Lite to ACR; also push to GHCR for reserved tags and version tags.
+          # A custom override_tag stays ACR-only even when consuming released upstream code: it
+          # names a one-off build, not a published artifact. Checked first, because SERVER_REF is
+          # a version tag whenever use_latest_core_version=true.
+          if [[ -n "$OVERRIDE_TAG" ]]; then
+            PUSH_TO_GHCR=false
+          elif [[ "$IMAGE_TAG" == "rc" || "$IMAGE_TAG" == "hotfix-rc" || "$IMAGE_TAG" == "dev" ]] || [[ "$SERVER_REF" =~ ^refs/tags/v ]]; then
             PUSH_TO_GHCR=true
           else
             PUSH_TO_GHCR=false

--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -437,6 +437,37 @@ jobs:
         id: revision
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      # metadata-action builds its `labels` and `annotations` outputs independently, each merging
+      # only its own input over the same generated defaults. Supplying just `labels` leaves the
+      # annotations at the raw defaults (title=self-host, version=<branch>, revision=github.sha).
+      # Build the custom set once here and feed it to both inputs so they cannot drift.
+      - name: Build custom image metadata
+        id: custom-meta
+        env:
+          IMAGE_TAG: ${{ needs.setup.outputs.image_tag }}
+          REVISION: ${{ steps.revision.outputs.sha }}
+          SERVER_REGISTRY: ${{ needs.setup.outputs.server_registry }}
+          SERVER_TAG: ${{ needs.setup.outputs.server_tag }}
+          WEB_IMAGE: ${{ needs.setup.outputs.web_image }}
+          WEB_TAG: ${{ needs.setup.outputs.web_tag }}
+        run: |
+          {
+            echo "items<<METADATA_EOF"
+            echo "org.opencontainers.image.title=Bitwarden Lite"
+            echo "org.opencontainers.image.description=All-in-one Bitwarden self-hosted container"
+            echo "org.opencontainers.image.vendor=Bitwarden Inc."
+            echo "org.opencontainers.image.licenses=GPL-3.0"
+            echo "org.opencontainers.image.url=https://bitwarden.com"
+            echo "org.opencontainers.image.source=https://github.com/bitwarden/self-host"
+            echo "org.opencontainers.image.version=${IMAGE_TAG}"
+            echo "org.opencontainers.image.revision=${REVISION}"
+            echo "com.bitwarden.server.registry=${SERVER_REGISTRY}"
+            echo "com.bitwarden.server.tag=${SERVER_TAG}"
+            echo "com.bitwarden.web.image=${WEB_IMAGE}"
+            echo "com.bitwarden.web.tag=${WEB_TAG}"
+            echo "METADATA_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Generate image metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -452,19 +483,8 @@ jobs:
             ghcr.io/bitwarden/lite
           # `version` and `revision` are overridden because this action derives both from the
           # git ref, which does not match our resolved image tag or the checked-out commit.
-          labels: |
-            org.opencontainers.image.title=Bitwarden Lite
-            org.opencontainers.image.description=All-in-one Bitwarden self-hosted container
-            org.opencontainers.image.vendor=Bitwarden Inc.
-            org.opencontainers.image.licenses=GPL-3.0
-            org.opencontainers.image.url=https://bitwarden.com
-            org.opencontainers.image.source=https://github.com/bitwarden/self-host
-            org.opencontainers.image.version=${{ needs.setup.outputs.image_tag }}
-            org.opencontainers.image.revision=${{ steps.revision.outputs.sha }}
-            com.bitwarden.server.registry=${{ needs.setup.outputs.server_registry }}
-            com.bitwarden.server.tag=${{ needs.setup.outputs.server_tag }}
-            com.bitwarden.web.image=${{ needs.setup.outputs.web_image }}
-            com.bitwarden.web.tag=${{ needs.setup.outputs.web_tag }}
+          labels: ${{ steps.custom-meta.outputs.items }}
+          annotations: ${{ steps.custom-meta.outputs.items }}
 
       - name: Build and push Docker image
         id: build-docker

--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -423,6 +423,42 @@ jobs:
             echo "Skipping tag check for non-version tag: ${IMAGE_TAG}"
           fi
 
+      # `github.sha` points at the triggering commit, which is NOT the built commit when
+      # `self_host_repo_ref` is supplied (dispatch/workflow_call). Read the actual checked-out
+      # HEAD so org.opencontainers.image.revision always names the commit that produced the image.
+      - name: Resolve built revision
+        id: revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          # Annotate the manifest list too, not just per-arch manifests, so the metadata is
+          # visible on the multi-arch index that clients actually resolve first.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
+        with:
+          # Tags come from the `image-ref` step, which encodes this repo's ACR/GHCR promotion
+          # rules. The `tags` output of this action is intentionally unused.
+          images: |
+            bitwardenprod.azurecr.io/lite
+            ghcr.io/bitwarden/lite
+          # `version` and `revision` are overridden because this action derives both from the
+          # git ref, which does not match our resolved image tag or the checked-out commit.
+          labels: |
+            org.opencontainers.image.title=Bitwarden Lite
+            org.opencontainers.image.description=All-in-one Bitwarden self-hosted container
+            org.opencontainers.image.vendor=Bitwarden Inc.
+            org.opencontainers.image.licenses=GPL-3.0
+            org.opencontainers.image.url=https://bitwarden.com
+            org.opencontainers.image.source=https://github.com/bitwarden/self-host
+            org.opencontainers.image.version=${{ needs.setup.outputs.image_tag }}
+            org.opencontainers.image.revision=${{ steps.revision.outputs.sha }}
+            com.bitwarden.server.registry=${{ needs.setup.outputs.server_registry }}
+            com.bitwarden.server.tag=${{ needs.setup.outputs.server_tag }}
+            com.bitwarden.web.image=${{ needs.setup.outputs.web_image }}
+            com.bitwarden.web.tag=${{ needs.setup.outputs.web_tag }}
+
       - name: Build and push Docker image
         id: build-docker
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -435,6 +471,8 @@ jobs:
             linux/arm64/v8
           push: ${{ steps.check-secrets.outputs.has_secrets == 'true' }}
           tags: ${{ steps.image-ref.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             SERVER_TAG=${{ needs.setup.outputs.server_tag }}
             SERVER_REGISTRY=${{ needs.setup.outputs.server_registry }}


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2166](https://bitwarden.atlassian.net/browse/BRE-2166)

## 📔 Objective

This PR adds metadata to the Bitwarden Lite container image. This metadata is useful for debugging.

There are also PRs opened in the following repositories:

- Server
- Key Connector

[BRE-2166]: https://bitwarden.atlassian.net/browse/BRE-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ