### PR TITLE
[BRE-2166] Remove license from container metadata

### DIFF
--- a/.github/workflows/build-bitwarden-lite.yml
+++ b/.github/workflows/build-bitwarden-lite.yml
@@ -450,7 +450,6 @@ jobs:
             echo "org.opencontainers.image.title=Bitwarden Lite"
             echo "org.opencontainers.image.description=All-in-one Bitwarden self-hosted container"
             echo "org.opencontainers.image.vendor=Bitwarden Inc."
-            echo "org.opencontainers.image.licenses=GPL-3.0"
             echo "org.opencontainers.image.url=https://bitwarden.com"
             echo "org.opencontainers.image.source=https://github.com/bitwarden/self-host"
             echo "org.opencontainers.image.version=${IMAGE_TAG}"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2166](https://bitwarden.atlassian.net/browse/BRE-2166)

## 📔 Objective

This PR removes the license field from the container image metadata. If we set the license it may conflict with the license of the base image and be inaccurate.

[BRE-2166]: https://bitwarden.atlassian.net/browse/BRE-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ